### PR TITLE
Fix path to core language file locallang_ttc.xlf

### DIFF
--- a/Configuration/FlexForms/Flexform_plugin.xml
+++ b/Configuration/FlexForms/Flexform_plugin.xml
@@ -306,27 +306,27 @@
                                 <type>select</type>
                                 <items type="array">
                                     <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.0</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.0</numIndex>
                                         <numIndex index="1">0</numIndex>
                                     </numIndex>
                                     <numIndex index="3" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.1</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.1</numIndex>
                                         <numIndex index="1">1</numIndex>
                                     </numIndex>
                                     <numIndex index="4" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.2</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.2</numIndex>
                                         <numIndex index="1">2</numIndex>
                                     </numIndex>
                                     <numIndex index="5" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.3</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.3</numIndex>
                                         <numIndex index="1">3</numIndex>
                                     </numIndex>
                                     <numIndex index="6" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.4</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.4</numIndex>
                                         <numIndex index="1">4</numIndex>
                                     </numIndex>
                                     <numIndex index="7" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.5</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.5</numIndex>
                                         <numIndex index="1">250</numIndex>
                                     </numIndex>
                                 </items>

--- a/Configuration/FlexForms/Flexform_userreg.xml
+++ b/Configuration/FlexForms/Flexform_userreg.xml
@@ -143,27 +143,27 @@
                                 <type>select</type>
                                 <items type="array">
                                     <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.0</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.0</numIndex>
                                         <numIndex index="1">0</numIndex>
                                     </numIndex>
                                     <numIndex index="3" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.1</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.1</numIndex>
                                         <numIndex index="1">1</numIndex>
                                     </numIndex>
                                     <numIndex index="4" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.2</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.2</numIndex>
                                         <numIndex index="1">2</numIndex>
                                     </numIndex>
                                     <numIndex index="5" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.3</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.3</numIndex>
                                         <numIndex index="1">3</numIndex>
                                     </numIndex>
                                     <numIndex index="6" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.4</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.4</numIndex>
                                         <numIndex index="1">4</numIndex>
                                     </numIndex>
                                     <numIndex index="7" type="array">
-                                        <numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.5</numIndex>
+                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.5</numIndex>
                                         <numIndex index="1">250</numIndex>
                                     </numIndex>
                                 </items>

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
@@ -69,7 +69,7 @@ return [
 			--div--;LLL:EXT:sf_event_mgt/Resources/Private/Language/locallang_db.xlf:event.tabs.payment,
                  enable_payment, restrict_payment_methods, selected_payment_methods,
 
-			--div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime, fe_group'
+			--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access, starttime, endtime, fe_group'
         ],
     ],
     'palettes' => [
@@ -240,7 +240,7 @@ return [
                         'module' => [
                             'name' => 'wizard_rte',
                         ],
-                        'title' => 'LLL:EXT:cms/locallang_ttc.xlf:bodytext.W.RTE',
+                        'title' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:bodytext.W.RTE',
                         'type' => 'script'
                     ]
                 ]
@@ -263,7 +263,7 @@ return [
                         'module' => [
                             'name' => 'wizard_rte',
                         ],
-                        'title' => 'LLL:EXT:cms/locallang_ttc.xlf:bodytext.W.RTE',
+                        'title' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:bodytext.W.RTE',
                         'type' => 'script'
                     ]
                 ]
@@ -484,7 +484,7 @@ return [
                 'image',
                 [
                     'appearance' => [
-                        'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
+                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference'
                     ],
                     'foreign_match_fields' => [
                         'fieldname' => 'image',
@@ -518,7 +518,7 @@ return [
             'label' => 'LLL:EXT:sf_event_mgt/Resources/Private/Language/locallang_db.xlf:tx_sfeventmgt_domain_model_event.files',
             'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('files', [
                 'appearance' => [
-                    'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:media.addFileReference'
+                    'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:media.addFileReference'
                 ],
             ]),
         ],
@@ -561,7 +561,7 @@ return [
                 'additional_image',
                 [
                     'appearance' => [
-                        'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
+                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference'
                     ],
                     'foreign_match_fields' => [
                         'fieldname' => 'additional_image',

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_location.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_location.php
@@ -34,7 +34,7 @@ return [
             ],
             'showitem' => 'l10n_parent, l10n_diffsource, --palette--;;paletteCore, title, address, zip,
             city, country, description, link, longitude, latitude,
-            --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime'
+            --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access, starttime, endtime'
         ],
     ],
     'palettes' => [
@@ -189,7 +189,7 @@ return [
                         'module' => [
                             'name' => 'wizard_rte',
                         ],
-                        'title' => 'LLL:EXT:cms/locallang_ttc.xlf:bodytext.W.RTE',
+                        'title' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:bodytext.W.RTE',
                         'type' => 'script'
                     ]
                 ]

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_organisator.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_organisator.php
@@ -120,7 +120,7 @@ return [
                 'image',
                 [
                     'appearance' => [
-                        'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
+                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference'
                     ],
                     'foreign_match_fields' => [
                         'fieldname' => 'image',

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_priceoption.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_priceoption.php
@@ -31,7 +31,7 @@ return [
     'types' => [
         '1' => [
             'showitem' => 'l10n_parent, l10n_diffsource, --palette--;;paletteCore, 
-            price, valid_until, --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime, fe_group'
+            price, valid_until, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access, starttime, endtime, fe_group'
         ],
     ],
     'palettes' => [

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_registration.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_registration.php
@@ -43,7 +43,7 @@ return [
             --div--;LLL:EXT:sf_event_mgt/Resources/Private/Language/locallang_db.xlf:event.tabs.payment,
                 paid, paymentmethod, payment_reference, 
                 
-            --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime'
+            --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access, starttime, endtime'
         ],
     ],
     'palettes' => [


### PR DESCRIPTION
This fixes issue with access tab not being rendered in the TYPO3 backend.
The old path has been deprecated in TYPO3 7.4 and is not working in 8.7.