### PR TITLE
Change type of param in doc header

### DIFF
--- a/Classes/Service/RegistrationService.php
+++ b/Classes/Service/RegistrationService.php
@@ -281,7 +281,7 @@ class RegistrationService
      *
      * @param \DERHANSEN\SfEventMgt\Domain\Model\Event $event Event
      * @param \DERHANSEN\SfEventMgt\Domain\Model\Registration $registration Registration
-     * @param RegistrationResult $result Result
+     * @param int $result Result
      *
      * @return bool
      */


### PR DESCRIPTION
The type of the param `$result` is declared as `RegistrationResult` while in fact the constants from that class are used to provide the status which is an integer.