### PR TITLE
override template paths to work with notifications

### DIFF
--- a/Classes/Service/FluidStandaloneService.php
+++ b/Classes/Service/FluidStandaloneService.php
@@ -43,11 +43,16 @@ class FluidStandaloneService
     public function getTemplateFolders($part = 'template')
     {
         $extbaseConfig = $this->configurationManager->getConfiguration(
-            ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
         );
+        /** @var \TYPO3\CMS\Extbase\Service\TypoScriptService $typoScriptService */
+        $typoScriptService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+            \TYPO3\CMS\Extbase\Service\TypoScriptService::class
+        );
+        $extbaseConfig = $typoScriptService->convertTypoScriptArrayToPlainArray($extbaseConfig);
 
-        if (!empty($extbaseConfig['view'][$part . 'RootPaths'])) {
-            $templatePaths = $extbaseConfig['view'][$part . 'RootPaths'];
+        if (!empty($extbaseConfig['module']['tx_sfeventmgt']['view'][$part . 'RootPaths'])) {
+            $templatePaths = $extbaseConfig['module']['tx_sfeventmgt']['view'][$part . 'RootPaths'];
             $templatePaths = array_values($templatePaths);
         }
         if (empty($templatePaths)) {


### PR DESCRIPTION
It works with \ext\sf_event_mgt\Resources\Private\Templates\Notification\User\Custom\ThanksForParticipation.html, but not with module.tx_sfeventmgt {
    view {
        templateRootPaths {