### PR TITLE
[BUGFIX] Fix error while formatting dateOfBirth in T3 8.7

### DIFF
--- a/Resources/Private/Templates/Notification/Admin/RegistrationCancelled.html
+++ b/Resources/Private/Templates/Notification/Admin/RegistrationCancelled.html
@@ -14,6 +14,6 @@
     <li>{registration.country}</li>
     <li>{registration.email}</li>
     <li>{registration.phone}</li>
-    <li>{f:format.date(date: '{registration.dateOfBirth}', format: 'd.m.Y')}</li>
+    <li>{f:format.date(date: registration.dateOfBirth, format: '%d.%m.%Y')}</li>
     <li>{registration.notes}</li>
 </ul>

--- a/Resources/Private/Templates/Notification/Admin/RegistrationConfirmed.html
+++ b/Resources/Private/Templates/Notification/Admin/RegistrationConfirmed.html
@@ -14,6 +14,6 @@
     <li>{registration.country}</li>
     <li>{registration.email}</li>
     <li>{registration.phone}</li>
-    <li>{f:format.date(date: '{registration.dateOfBirth}', format: 'd.m.Y')}</li>
+    <li>{f:format.date(date: registration.dateOfBirth, format: '%d.%m.%Y')}</li>
     <li>{registration.notes}</li>
 </ul>

--- a/Resources/Private/Templates/Notification/Admin/RegistrationNew.html
+++ b/Resources/Private/Templates/Notification/Admin/RegistrationNew.html
@@ -10,7 +10,7 @@
     <li>{registration.country}</li>
     <li>{registration.email}</li>
     <li>{registration.phone}</li>
-    <li>{f:format.date(date: registration.dateOfBirth, format: 'd.m.Y')}</li>
+    <li>{f:format.date(date: registration.dateOfBirth, format: '%d.%m.%Y')}</li>
     <li>{registration.notes}</li>
 </ul>
 

--- a/Resources/Private/Templates/Notification/Admin/RegistrationWaitlistConfirmed.html
+++ b/Resources/Private/Templates/Notification/Admin/RegistrationWaitlistConfirmed.html
@@ -14,6 +14,6 @@
     <li>{registration.country}</li>
     <li>{registration.email}</li>
     <li>{registration.phone}</li>
-    <li>{f:format.date(date: '{registration.dateOfBirth}', format: 'd.m.Y')}</li>
+    <li>{f:format.date(date: registration.dateOfBirth, format: '%d.%m.%Y')}</li>
     <li>{registration.notes}</li>
 </ul>

--- a/Resources/Private/Templates/Notification/Admin/RegistrationWaitlistNew.html
+++ b/Resources/Private/Templates/Notification/Admin/RegistrationWaitlistNew.html
@@ -10,7 +10,7 @@
     <li>{registration.country}</li>
     <li>{registration.email}</li>
     <li>{registration.phone}</li>
-    <li>{f:format.date(date: registration.dateOfBirth, format: 'd.m.Y')}</li>
+    <li>{f:format.date(date: registration.dateOfBirth, format: '%d.%m.%Y')}</li>
     <li>{registration.notes}</li>
 </ul>
 


### PR DESCRIPTION
The error ```#1476107295: PHP Warning: htmlspecialchars() expects parameter 1 to be string, object given in /vendor/typo3fluid/fluid/src/Core/Parser/SyntaxTree/EscapingNode.php line 44```
occurs in TYPO3 8.7. 

This patch uses the same syntax of the viewhelper as in formatting the event date in the file