### PR TITLE
[FEATURE] Check in detail and registration view if event belongs to r…

### DIFF
--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -345,6 +345,10 @@ class EventController extends AbstractController
             $event = $this->eventRepository->findByUid((int)$this->settings['singleEvent']);
         }
 
+        if (is_a($event, Event::class) && $this->settings['detail']['checkPidOfEventRecord']) {
+            $event = $this->checkPidOfEventRecord($event);
+        }
+
         if (is_null($event) && isset($this->settings['event']['errorHandling'])) {
             return $this->handleEventNotFoundError($this->settings);
         }
@@ -401,6 +405,9 @@ class EventController extends AbstractController
      */
     public function icalDownloadAction(Event $event = null)
     {
+        if (is_a($event, Event::class) && $this->settings['detail']['checkPidOfEventRecord']) {
+            $event = $this->checkPidOfEventRecord($event);
+        }
         if (is_null($event) && isset($this->settings['event']['errorHandling'])) {
             return $this->handleEventNotFoundError($this->settings);
         }
@@ -418,6 +425,9 @@ class EventController extends AbstractController
      */
     public function registrationAction(Event $event = null)
     {
+        if (is_a($event, Event::class) && $this->settings['registration']['checkPidOfEventRecord']) {
+            $event = $this->checkPidOfEventRecord($event);
+        }
         if (is_null($event) && isset($this->settings['event']['errorHandling'])) {
             return $this->handleEventNotFoundError($this->settings);
         }
@@ -534,10 +544,16 @@ class EventController extends AbstractController
      * @validate $registration \DERHANSEN\SfEventMgt\Validation\Validator\RegistrationFieldValidator
      * @validate $registration \DERHANSEN\SfEventMgt\Validation\Validator\RegistrationValidator
      *
-     * @return void
+     * @return mixed string|void
      */
     public function saveRegistrationAction(Registration $registration, Event $event)
     {
+        if (is_a($event, Event::class) && $this->settings['registration']['checkPidOfEventRecord']) {
+            $event = $this->checkPidOfEventRecord($event);
+        }
+        if (is_null($event) && isset($this->settings['event']['errorHandling'])) {
+            return $this->handleEventNotFoundError($this->settings);
+        }
         $autoConfirmation = (bool)$this->settings['registration']['autoConfirmation'] || $event->getEnableAutoconfirm();
         $result = RegistrationResult::REGISTRATION_SUCCESSFUL;
         $success = $this->registrationService->checkRegistrationSuccess($event, $registration, $result);
@@ -936,7 +952,7 @@ class EventController extends AbstractController
     {
         $cacheTags = [];
         foreach ($eventRecords as $event) {
-            // cache tag for each news record
+            // cache tag for each event record
             $cacheTags[] = 'tx_sfeventmgt_uid_' . $event->getUid();
         }
         if (count($cacheTags) > 0) {
@@ -962,5 +978,37 @@ class EventController extends AbstractController
         if (count($cacheTags) > 0) {
             $this->getTypoScriptFrontendController()->addCacheTags($cacheTags);
         }
+    }
+
+    /**
+     * Checks if the event pid could be found in the storagePage settings of the detail plugin and
+     * if the pid could not be found it return null instead of the event object.
+     *
+     * @param \DERHANSEN\SfEventMgt\Domain\Model\Event $event
+     * @return null|\DERHANSEN\SfEventMgt\Domain\Model\Event
+     */
+    protected function checkPidOfEventRecord(Event $event)
+    {
+        $allowedStoragePages = GeneralUtility::trimExplode(
+            ',',
+            Page::extendPidListByChildren(
+                $this->settings['storagePage'],
+                $this->settings['recursive']
+            ),
+            true
+        );
+        if (count($allowedStoragePages) > 0 && !in_array($event->getPid(), $allowedStoragePages)) {
+            $this->signalSlotDispatcher->dispatch(
+                __CLASS__,
+                'checkPidOfEventRecordFailedInDetailAction',
+                [
+                    'event' => $event,
+                    'eventController' => $this
+                ]
+            );
+            $event = null;
+        }
+
+        return $event;
     }
 }

--- a/Configuration/FlexForms/Flexform_plugin.xml
+++ b/Configuration/FlexForms/Flexform_plugin.xml
@@ -360,12 +360,6 @@
                         <TCEforms>
                             <exclude>1</exclude>
                             <label>LLL:EXT:sf_event_mgt/Resources/Private/Language/locallang_be.xlf:flexforms_general.storagePage</label>
-                            <displayCond>
-                                <AND>
-                                    <numIndex index="0">FIELD:switchableControllerActions:!=:Event->detail;Event->icalDownload</numIndex>
-                                    <numIndex index="1">FIELD:switchableControllerActions:!=:Event->registration;Event->saveRegistration;Event->saveRegistrationResult;Event->confirmRegistration;Event->cancelRegistration</numIndex>
-                                </AND>
-                            </displayCond>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>
@@ -387,12 +381,6 @@
                     <settings.recursive>
                         <TCEforms>
                             <label>LLL:EXT:lang/locallang_general.xlf:LGL.recursive</label>
-                            <displayCond>
-                                <AND>
-                                    <numIndex index="0">FIELD:switchableControllerActions:!=:Event->detail;Event->icalDownload</numIndex>
-                                    <numIndex index="1">FIELD:switchableControllerActions:!=:Event->registration;Event->saveRegistration;Event->saveRegistrationResult;Event->confirmRegistration;Event->cancelRegistration</numIndex>
-                                </AND>
-                            </displayCond>
                             <config>
                                 <type>select</type>
                                 <items type="array">

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -43,6 +43,7 @@ plugin.tx_sfeventmgt {
             showWeekNumber = 1
         }
         detail {
+            checkPidOfEventRecord = 0
             imageWidth = 200
             imageHeight =
         }
@@ -52,6 +53,7 @@ plugin.tx_sfeventmgt {
             formatDateOfBirth = {$plugin.tx_sfeventmgt.settings.registration.formatDateOfBirth}
             # The fields firstname, lastname and email are always required and cannot be overridden
             requiredFields =
+            checkPidOfEventRecord = 0
             # Prefill fields - registration field = fe_user field
             prefillFields {
                 firstname = first_name

--- a/Tests/Unit/Controller/EventControllerTest.php
+++ b/Tests/Unit/Controller/EventControllerTest.php
@@ -9,6 +9,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Controller;
  */
 
 use DERHANSEN\SfEventMgt\Controller\EventController;
+use DERHANSEN\SfEventMgt\Domain\Model\Event;
 use DERHANSEN\SfEventMgt\Domain\Repository\EventRepository;
 use DERHANSEN\SfEventMgt\Domain\Repository\RegistrationRepository;
 use DERHANSEN\SfEventMgt\Utility\RegistrationResult;
@@ -2245,5 +2246,36 @@ class EventControllerTest extends UnitTestCase
         $this->assertEquals(0, $resultDemand->getYear());
         $this->assertSame('26.12.2016 00:00:00', $resultDemand->getSearchDemand()->getStartDate()->format('d.m.Y H:i:s'));
         $this->assertSame('05.02.2017 23:59:59', $resultDemand->getSearchDemand()->getEndDate()->format('d.m.Y H:i:s'));
+    }
+
+    /**
+     * @test
+     */
+    public function checkPidOfEventRecordWorks()
+    {
+        $mockedSignalDispatcher = $this->getAccessibleMock('\TYPO3\CMS\Extbase\SignalSlot\Dispatcher', ['dummy']);
+        $mockedController = $this->getAccessibleMock('DERHANSEN\\SfEventMgt\\Controller\\EventController',
+            ['dummy']);
+        $mockedController->_set('signalSlotDispatcher', $mockedSignalDispatcher);
+
+        $news = new Event();
+
+        // No startingpoint
+        $mockedController->_set('settings', ['storagePage' => '']);
+        $news->setPid(12);
+
+        $this->assertEquals($news, $mockedController->_call('checkPidOfEventRecord', $news));
+
+        // startingpoint defined
+        $mockedController->_set('settings', ['storagePage' => '1,2,123,456']);
+        $news->setPid(123);
+
+        $this->assertEquals($news, $mockedController->_call('checkPidOfEventRecord', $news));
+
+        // startingpoint is different
+        $mockedController->_set('settings', ['storagePage' => '123,456']);
+        $news->setPid(12);
+
+        $this->assertEquals(null, $mockedController->_call('checkPidOfEventRecord', $news));
     }
 }


### PR DESCRIPTION
…ight page

You could set the recursive storage page also for the detail and registration
view now and if the pid of the event to be shown isn't found in the settings,
the error handling is triggered.