### PR TITLE
Cleanup tests

### DIFF
--- a/Tests/Unit/Command/CleanupCommandControllerTest.php
+++ b/Tests/Unit/Command/CleanupCommandControllerTest.php
@@ -8,7 +8,11 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Command;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Command\CleanupCommandController;
+use DERHANSEN\SfEventMgt\Service\RegistrationService;
+use DERHANSEN\SfEventMgt\Service\UtilityService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 
 /**
  * Test case for class DERHANSEN\SfEventMgt\Command\CleanupCommandController.
@@ -29,7 +33,7 @@ class CleanupCommandControllerTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Command\CleanupCommandController();
+        $this->subject = new CleanupCommandController();
     }
 
     /**
@@ -62,7 +66,7 @@ class CleanupCommandControllerTest extends UnitTestCase
             ]
         ];
 
-        $configurationManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager')
+        $configurationManager = $this->getMockBuilder(ConfigurationManager::class)
             ->setMethods(['getConfiguration'])
             ->getMock();
         $configurationManager->expects($this->once())->method('getConfiguration')->will(
@@ -70,7 +74,7 @@ class CleanupCommandControllerTest extends UnitTestCase
         );
         $this->inject($this->subject, 'configurationManager', $configurationManager);
 
-        $registrationService = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Service\\RegistrationService')
+        $registrationService = $this->getMockBuilder(RegistrationService::class)
             ->setMethods(['handleExpiredRegistrations'])
             ->getMock();
         $registrationService->expects($this->once())->method('handleExpiredRegistrations')->with(0)->will(
@@ -78,7 +82,7 @@ class CleanupCommandControllerTest extends UnitTestCase
         );
         $this->inject($this->subject, 'registrationService', $registrationService);
 
-        $utilityService = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Service\\UtilityService')
+        $utilityService = $this->getMockBuilder(UtilityService::class)
             ->setMethods(['clearCacheForConfiguredUids'])
             ->getMock();
         $utilityService->expects($this->once())->method('clearCacheForConfiguredUids')->

--- a/Tests/Unit/Controller/AdministrationControllerTest.php
+++ b/Tests/Unit/Controller/AdministrationControllerTest.php
@@ -8,10 +8,25 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Controller;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Controller\AdministrationController;
+use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Domain\Model\Dto\EventDemand;
+use DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand;
 use DERHANSEN\SfEventMgt\Domain\Repository\CustomNotificationLogRepository;
+use DERHANSEN\SfEventMgt\Domain\Repository\EventRepository;
 use DERHANSEN\SfEventMgt\Service\BeUserSessionService;
 use DERHANSEN\SfEventMgt\Service\ExportService;
+use DERHANSEN\SfEventMgt\Service\NotificationService;
+use DERHANSEN\SfEventMgt\Service\RegistrationService;
+use DERHANSEN\SfEventMgt\Service\SettingsService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Mvc\Controller\Argument;
+use TYPO3\CMS\Extbase\Mvc\Controller\Arguments;
+use TYPO3\CMS\Extbase\Mvc\Controller\MvcPropertyMappingConfiguration;
+use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
 
 /**
  * Test case for class DERHANSEN\SfEventMgt\Controller\AdministrationController.
@@ -33,7 +48,7 @@ class AdministrationControllerTest extends UnitTestCase
     protected function setUp()
     {
         $this->subject = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\Controller\\AdministrationController',
+            AdministrationController::class,
             ['redirect', 'forward', 'addFlashMessage', 'redirectToUri'],
             [],
             '',
@@ -68,14 +83,14 @@ class AdministrationControllerTest extends UnitTestCase
      */
     public function listActionFetchesEventsFromRepositoryForNoStoragePageAndAssignsThemToView()
     {
-        $allEvents = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')->getMock();
+        $allEvents = $this->getMockBuilder(ObjectStorage::class)->getMock();
 
-        $demand = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Dto\\EventDemand')
+        $demand = $this->getMockBuilder(EventDemand::class)
             ->setMethods(['setSearchDemand'])
             ->getMock();
         $demand->expects($this->once())->method('setSearchDemand')->with(null);
 
-        $objectManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Object\\ObjectManager')
+        $objectManager = $this->getMockBuilder(ObjectManager::class)
             ->setMethods(['get'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -91,7 +106,7 @@ class AdministrationControllerTest extends UnitTestCase
         $exportService->expects($this->once())->method('hasWriteAccessToTempFolder')->will($this->returnValue(true));
         $this->inject($this->subject, 'exportService', $exportService);
 
-        $eventRepository = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Repository\\EventRepository')
+        $eventRepository = $this->getMockBuilder(EventRepository::class)
             ->setMethods(['findDemanded'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -99,7 +114,7 @@ class AdministrationControllerTest extends UnitTestCase
         $eventRepository->expects($this->once())->method('findDemanded')->will($this->returnValue($allEvents));
         $this->inject($this->subject, 'eventRepository', $eventRepository);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $view->expects($this->once())->method('assignMultiple')->with([
             'events' => $allEvents,
             'searchDemand' => $searchDemand,
@@ -116,15 +131,15 @@ class AdministrationControllerTest extends UnitTestCase
      */
     public function listActionFetchesEventsFromRepositoryForNoStoragePageAndGivenDemandAndAssignsThemToView()
     {
-        $searchDemand = new \DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand();
-        $allEvents = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')->getMock();
+        $searchDemand = new SearchDemand();
+        $allEvents = $this->getMockBuilder(ObjectStorage::class)->getMock();
 
-        $demand = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Dto\\EventDemand')
+        $demand = $this->getMockBuilder(EventDemand::class)
             ->setMethods(['setSearchDemand'])
             ->getMock();
         $demand->expects($this->once())->method('setSearchDemand')->with($searchDemand);
 
-        $objectManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Object\\ObjectManager')
+        $objectManager = $this->getMockBuilder(ObjectManager::class)
             ->setMethods(['get'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -139,14 +154,14 @@ class AdministrationControllerTest extends UnitTestCase
         $exportService->expects($this->once())->method('hasWriteAccessToTempFolder')->will($this->returnValue(true));
         $this->inject($this->subject, 'exportService', $exportService);
 
-        $eventRepository = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Repository\\EventRepository')
+        $eventRepository = $this->getMockBuilder(EventRepository::class)
             ->setMethods(['findDemanded'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventRepository->expects($this->once())->method('findDemanded')->will($this->returnValue($allEvents));
         $this->inject($this->subject, 'eventRepository', $eventRepository);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $view->expects($this->once())->method('assignMultiple')->with([
             'events' => $allEvents,
             'searchDemand' => $searchDemand,
@@ -165,16 +180,16 @@ class AdministrationControllerTest extends UnitTestCase
     {
         $this->subject->_set('pid', 1);
 
-        $searchDemand = new \DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand();
-        $allEvents = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')->getMock();
+        $searchDemand = new SearchDemand();
+        $allEvents = $this->getMockBuilder(ObjectStorage::class)->getMock();
 
-        $demand = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Dto\\EventDemand')
+        $demand = $this->getMockBuilder(EventDemand::class)
             ->setMethods(['setSearchDemand', 'setStoragePage'])
             ->getMock();
         $demand->expects($this->any())->method('setSearchDemand')->with($searchDemand);
         $demand->expects($this->any())->method('setStoragePage')->with(1);
 
-        $objectManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Object\\ObjectManager')
+        $objectManager = $this->getMockBuilder(ObjectManager::class)
             ->setMethods(['get'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -189,13 +204,13 @@ class AdministrationControllerTest extends UnitTestCase
         $exportService->expects($this->once())->method('hasWriteAccessToTempFolder')->will($this->returnValue(true));
         $this->inject($this->subject, 'exportService', $exportService);
 
-        $eventRepository = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Repository\\EventRepository')
+        $eventRepository = $this->getMockBuilder(EventRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
         $eventRepository->expects($this->once())->method('findDemanded')->will($this->returnValue($allEvents));
         $this->inject($this->subject, 'eventRepository', $eventRepository);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $view->expects($this->once())->method('assignMultiple')->with([
             'events' => $allEvents,
             'searchDemand' => $searchDemand,
@@ -214,14 +229,14 @@ class AdministrationControllerTest extends UnitTestCase
     {
         $this->subject->_set('pid', 1);
 
-        $searchDemand = new \DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand();
-        $allEvents = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')->getMock();
+        $searchDemand = new SearchDemand();
+        $allEvents = $this->getMockBuilder(ObjectStorage::class)->getMock();
 
-        $demand = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Dto\\EventDemand')->getMock();
+        $demand = $this->getMockBuilder(EventDemand::class)->getMock();
         $demand->expects($this->any())->method('setSearchDemand')->with($searchDemand);
         $demand->expects($this->any())->method('setStoragePage')->with(1);
 
-        $objectManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Object\\ObjectManager')
+        $objectManager = $this->getMockBuilder(ObjectManager::class)
             ->disableOriginalConstructor()
             ->getMock();
         $objectManager->expects($this->any())->method('get')->will($this->returnValue($demand));
@@ -235,13 +250,13 @@ class AdministrationControllerTest extends UnitTestCase
         $exportService->expects($this->once())->method('hasWriteAccessToTempFolder')->will($this->returnValue(true));
         $this->inject($this->subject, 'exportService', $exportService);
 
-        $eventRepository = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Repository\\EventRepository')
+        $eventRepository = $this->getMockBuilder(EventRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
         $eventRepository->expects($this->once())->method('findDemanded')->will($this->returnValue($allEvents));
         $this->inject($this->subject, 'eventRepository', $eventRepository);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
 
         $view->expects($this->once())->method('assignMultiple')->with([
             'showMessage' => true,
@@ -266,41 +281,41 @@ class AdministrationControllerTest extends UnitTestCase
     protected function getInitializeListActionArgumentMock($settingsSearchDateFormat = null)
     {
         $mockPropertyMapperConfig = $this->getMockBuilder(
-            'TYPO3\\CMS\\Extbase\\Mvc\\Controller\\MvcPropertyMappingConfiguration'
+            MvcPropertyMappingConfiguration::class
         )->getMock();
         $mockPropertyMapperConfig->expects($this->any())->method('setTypeConverterOption')->with(
-            $this->equalTo('TYPO3\\CMS\\Extbase\\Property\\TypeConverter\\DateTimeConverter'),
+            $this->equalTo(DateTimeConverter::class),
             $this->equalTo('dateFormat'),
             $this->equalTo($settingsSearchDateFormat)
         );
 
         $mockStartDatePmConfig = $this->getMockBuilder(
-            'TYPO3\\CMS\\Extbase\\Mvc\\Controller\\MvcPropertyMappingConfiguration'
+            MvcPropertyMappingConfiguration::class
         )->getMock();
         $mockStartDatePmConfig->expects($this->once())->method('forProperty')->with('startDate')->will(
             $this->returnValue($mockPropertyMapperConfig)
         );
         $mockEndDatePmConfig = $this->getMockBuilder(
-            'TYPO3\\CMS\\Extbase\\Mvc\\Controller\\MvcPropertyMappingConfiguration'
+            MvcPropertyMappingConfiguration::class
         )->getMock();
         $mockEndDatePmConfig->expects($this->once())->method('forProperty')->with('endDate')->will(
             $this->returnValue($mockPropertyMapperConfig)
         );
 
-        $mockStartDateArgument = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Controller\\Argument')
+        $mockStartDateArgument = $this->getMockBuilder(Argument::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockStartDateArgument->expects($this->once())->method('getPropertyMappingConfiguration')->will(
             $this->returnValue($mockStartDatePmConfig)
         );
-        $mockEndDateArgument = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Controller\\Argument')
+        $mockEndDateArgument = $this->getMockBuilder(Argument::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockEndDateArgument->expects($this->once())->method('getPropertyMappingConfiguration')->will(
             $this->returnValue($mockEndDatePmConfig)
         );
 
-        $mockArguments = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Controller\\Arguments')->getMock();
+        $mockArguments = $this->getMockBuilder(Arguments::class)->getMock();
         $mockArguments->expects($this->at(0))->method('getArgument')->with('searchDemand')->will(
             $this->returnValue($mockStartDateArgument)
         );
@@ -348,7 +363,7 @@ class AdministrationControllerTest extends UnitTestCase
         $settings = [
             'csvExport' => ['some settings']
         ];
-        $exportService = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Service\\ExportService')->getMock();
+        $exportService = $this->getMockBuilder(ExportService::class)->getMock();
         $exportService->expects($this->once())->method('downloadRegistrationsCsv')->with(
             $this->equalTo(1),
             $this->equalTo(['some settings'])
@@ -364,7 +379,7 @@ class AdministrationControllerTest extends UnitTestCase
      */
     public function handleExpiredRegistrationsCallsServiceAndRedirectsToListView()
     {
-        $mockRegistrationService = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Service\\RegistrationService')
+        $mockRegistrationService = $this->getMockBuilder(RegistrationService::class)
             ->getMock();
         $mockRegistrationService->expects($this->once())->method('handleExpiredRegistrations');
         $this->inject($this->subject, 'registrationService', $mockRegistrationService);
@@ -381,7 +396,7 @@ class AdministrationControllerTest extends UnitTestCase
     {
         $customNotifications = ['key' => 'value'];
         $logEntries = ['SomeResult'];
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
 
         $mockLogRepo = $this->getMockBuilder(CustomNotificationLogRepository::class)
             ->setMethods(['findByEvent'])
@@ -392,13 +407,13 @@ class AdministrationControllerTest extends UnitTestCase
         );
         $this->inject($this->subject, 'customNotificationLogRepository', $mockLogRepo);
 
-        $mockSettingsService = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Service\\SettingsService')->getMock();
+        $mockSettingsService = $this->getMockBuilder(SettingsService::class)->getMock();
         $mockSettingsService->expects($this->once())->method('getCustomNotifications')->will(
             $this->returnValue($customNotifications)
         );
         $this->inject($this->subject, 'settingsService', $mockSettingsService);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $view->expects($this->once())->method('assignMultiple')->with($this->equalTo(
             ['event' => $event, 'customNotifications' => $customNotifications, 'logEntries' => $logEntries]
         ));
@@ -414,15 +429,15 @@ class AdministrationControllerTest extends UnitTestCase
     public function notifyActionSendsNotificationsLogsAndRedirects()
     {
         $customNotifications = ['key' => 'value'];
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
 
-        $mockSettingsService = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Service\\SettingsService')->getMock();
+        $mockSettingsService = $this->getMockBuilder(SettingsService::class)->getMock();
         $mockSettingsService->expects($this->once())->method('getCustomNotifications')->will(
             $this->returnValue($customNotifications)
         );
         $this->inject($this->subject, 'settingsService', $mockSettingsService);
 
-        $mockNotificationService = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Service\\NotificationService')
+        $mockNotificationService = $this->getMockBuilder(NotificationService::class)
             ->getMock();
         $mockNotificationService->expects($this->once())->method('sendCustomNotification')->will(
             $this->returnValue(1)

--- a/Tests/Unit/Controller/AdministrationControllerTest.php
+++ b/Tests/Unit/Controller/AdministrationControllerTest.php
@@ -9,9 +9,9 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Controller;
  */
 
 use DERHANSEN\SfEventMgt\Controller\AdministrationController;
-use DERHANSEN\SfEventMgt\Domain\Model\Event;
 use DERHANSEN\SfEventMgt\Domain\Model\Dto\EventDemand;
 use DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand;
+use DERHANSEN\SfEventMgt\Domain\Model\Event;
 use DERHANSEN\SfEventMgt\Domain\Repository\CustomNotificationLogRepository;
 use DERHANSEN\SfEventMgt\Domain\Repository\EventRepository;
 use DERHANSEN\SfEventMgt\Service\BeUserSessionService;

--- a/Tests/Unit/Controller/EventControllerTest.php
+++ b/Tests/Unit/Controller/EventControllerTest.php
@@ -9,12 +9,12 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Controller;
  */
 
 use DERHANSEN\SfEventMgt\Controller\EventController;
-use DERHANSEN\SfEventMgt\Domain\Model\Event;
-use DERHANSEN\SfEventMgt\Domain\Model\Registration;
 use DERHANSEN\SfEventMgt\Domain\Model\Dto\CategoryDemand;
 use DERHANSEN\SfEventMgt\Domain\Model\Dto\EventDemand;
 use DERHANSEN\SfEventMgt\Domain\Model\Dto\ForeignRecordDemand;
 use DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand;
+use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Domain\Model\Registration;
 use DERHANSEN\SfEventMgt\Domain\Repository\CategoryRepository;
 use DERHANSEN\SfEventMgt\Domain\Repository\EventRepository;
 use DERHANSEN\SfEventMgt\Domain\Repository\LocationRepository;
@@ -34,7 +34,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\MvcPropertyMappingConfiguration;
 use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
-use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
 use TYPO3\CMS\Extbase\Property\TypeConverter\PersistentObjectConverter;

--- a/Tests/Unit/Controller/PaymentControllerTest.php
+++ b/Tests/Unit/Controller/PaymentControllerTest.php
@@ -8,7 +8,13 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Controller;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Registration;
+use DERHANSEN\SfEventMgt\Controller\PaymentController;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
+use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
+use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 /**
  * Test case for class DERHANSEN\SfEventMgt\Controller\PaymentController.
@@ -30,7 +36,7 @@ class PaymentControllerTest extends UnitTestCase
     protected function setUp()
     {
         $this->subject = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\Controller\\PaymentController',
+            PaymentController::class,
             [
                 'redirect',
                 'validateHmacForAction',
@@ -60,16 +66,16 @@ class PaymentControllerTest extends UnitTestCase
      */
     public function redirectActionCallsBeforeRedirectSignal()
     {
-        $mockRegistration = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Registration')->getMock();
+        $mockRegistration = $this->getMockBuilder(Registration::class)->getMock();
         $mockRegistration->expects($this->once())->method('getPaymentmethod')->will($this->returnValue('paypal'));
 
-        $mockUriBuilder = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilder = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setUseCacheHash', 'uriFor'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->inject($this->subject, 'uriBuilder', $mockUriBuilder);
 
-        $mockHashService = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Security\\Cryptography\\HashService')->getMock();
+        $mockHashService = $this->getMockBuilder(HashService::class)->getMock();
         $this->inject($this->subject, 'hashService', $mockHashService);
 
         $values = [
@@ -84,15 +90,15 @@ class PaymentControllerTest extends UnitTestCase
         $updateRegistration = false;
         $arguments = [&$values, &$updateRegistration, $mockRegistration, $this->subject];
 
-        $mockedSignalSlotDispatcher = $this->getAccessibleMock('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher', ['dispatch']);
+        $mockedSignalSlotDispatcher = $this->getAccessibleMock(Dispatcher::class, ['dispatch']);
         $mockedSignalSlotDispatcher->expects($this->once())->method('dispatch')->with(
-            'DERHANSEN\SfEventMgt\Controller\PaymentController',
+            PaymentController::class,
             'redirectActionBeforeRedirectPaypal',
             $arguments
         );
         $this->subject->_set('signalSlotDispatcher', $mockedSignalSlotDispatcher);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $this->inject($this->subject, 'view', $view);
 
         $this->subject->redirectAction($mockRegistration, 'a-hmac');
@@ -106,16 +112,16 @@ class PaymentControllerTest extends UnitTestCase
      */
     public function successActionCallsProcessSuccessSignal()
     {
-        $mockRegistration = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Registration')->getMock();
+        $mockRegistration = $this->getMockBuilder(Registration::class)->getMock();
         $mockRegistration->expects($this->once())->method('getPaymentmethod')->will($this->returnValue('paypal'));
 
-        $mockUriBuilder = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilder = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setUseCacheHash', 'uriFor'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->inject($this->subject, 'uriBuilder', $mockUriBuilder);
 
-        $mockHashService = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Security\\Cryptography\\HashService')->getMock();
+        $mockHashService = $this->getMockBuilder(HashService::class)->getMock();
         $this->inject($this->subject, 'hashService', $mockHashService);
 
         $values = [
@@ -124,15 +130,15 @@ class PaymentControllerTest extends UnitTestCase
         $updateRegistration = false;
         $arguments = [&$values, &$updateRegistration, $mockRegistration, [], $this->subject];
 
-        $mockedSignalSlotDispatcher = $this->getAccessibleMock('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher', ['dispatch']);
+        $mockedSignalSlotDispatcher = $this->getAccessibleMock(Dispatcher::class, ['dispatch']);
         $mockedSignalSlotDispatcher->expects($this->once())->method('dispatch')->with(
-            'DERHANSEN\SfEventMgt\Controller\PaymentController',
+            PaymentController::class,
             'successActionProcessSuccessPaypal',
             $arguments
         );
         $this->subject->_set('signalSlotDispatcher', $mockedSignalSlotDispatcher);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $this->inject($this->subject, 'view', $view);
 
         $this->subject->successAction($mockRegistration, 'a-hmac');
@@ -146,16 +152,16 @@ class PaymentControllerTest extends UnitTestCase
      */
     public function failureActionCallsProcessFailureSignal()
     {
-        $mockRegistration = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Registration')->getMock();
+        $mockRegistration = $this->getMockBuilder(Registration::class)->getMock();
         $mockRegistration->expects($this->once())->method('getPaymentmethod')->will($this->returnValue('paypal'));
 
-        $mockUriBuilder = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilder = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setUseCacheHash', 'uriFor'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->inject($this->subject, 'uriBuilder', $mockUriBuilder);
 
-        $mockHashService = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Security\\Cryptography\\HashService')->getMock();
+        $mockHashService = $this->getMockBuilder(HashService::class)->getMock();
         $this->inject($this->subject, 'hashService', $mockHashService);
 
         $values = [
@@ -165,15 +171,15 @@ class PaymentControllerTest extends UnitTestCase
         $removeRegistration = false;
         $arguments = [&$values, &$updateRegistration, &$removeRegistration, $mockRegistration, [], $this->subject];
 
-        $mockedSignalSlotDispatcher = $this->getAccessibleMock('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher', ['dispatch']);
+        $mockedSignalSlotDispatcher = $this->getAccessibleMock(Dispatcher::class, ['dispatch']);
         $mockedSignalSlotDispatcher->expects($this->once())->method('dispatch')->with(
-            'DERHANSEN\SfEventMgt\Controller\PaymentController',
+            PaymentController::class,
             'failureActionProcessFailurePaypal',
             $arguments
         );
         $this->subject->_set('signalSlotDispatcher', $mockedSignalSlotDispatcher);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $this->inject($this->subject, 'view', $view);
 
         $this->subject->failureAction($mockRegistration, 'a-hmac');
@@ -187,16 +193,16 @@ class PaymentControllerTest extends UnitTestCase
      */
     public function cancelActionCallsProcessCancelSignal()
     {
-        $mockRegistration = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Registration')->getMock();
+        $mockRegistration = $this->getMockBuilder(Registration::class)->getMock();
         $mockRegistration->expects($this->once())->method('getPaymentmethod')->will($this->returnValue('paypal'));
 
-        $mockUriBuilder = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilder = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setUseCacheHash', 'uriFor'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->inject($this->subject, 'uriBuilder', $mockUriBuilder);
 
-        $mockHashService = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Security\\Cryptography\\HashService')->getMock();
+        $mockHashService = $this->getMockBuilder(HashService::class)->getMock();
         $this->inject($this->subject, 'hashService', $mockHashService);
 
         $values = [
@@ -206,15 +212,15 @@ class PaymentControllerTest extends UnitTestCase
         $removeRegistration = false;
         $arguments = [&$values, &$updateRegistration, &$removeRegistration, $mockRegistration, [], $this->subject];
 
-        $mockedSignalSlotDispatcher = $this->getAccessibleMock('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher', ['dispatch']);
+        $mockedSignalSlotDispatcher = $this->getAccessibleMock(Dispatcher::class, ['dispatch']);
         $mockedSignalSlotDispatcher->expects($this->once())->method('dispatch')->with(
-            'DERHANSEN\SfEventMgt\Controller\PaymentController',
+            PaymentController::class,
             'cancelActionProcessCancelPaypal',
             $arguments
         );
         $this->subject->_set('signalSlotDispatcher', $mockedSignalSlotDispatcher);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $this->inject($this->subject, 'view', $view);
 
         $this->subject->cancelAction($mockRegistration, 'a-hmac');
@@ -228,16 +234,16 @@ class PaymentControllerTest extends UnitTestCase
      */
     public function notifyActionCallsProcessNotifySignal()
     {
-        $mockRegistration = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Registration')->getMock();
+        $mockRegistration = $this->getMockBuilder(Registration::class)->getMock();
         $mockRegistration->expects($this->once())->method('getPaymentmethod')->will($this->returnValue('paypal'));
 
-        $mockUriBuilder = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilder = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setUseCacheHash', 'uriFor'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->inject($this->subject, 'uriBuilder', $mockUriBuilder);
 
-        $mockHashService = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Security\\Cryptography\\HashService')->getMock();
+        $mockHashService = $this->getMockBuilder(HashService::class)->getMock();
         $this->inject($this->subject, 'hashService', $mockHashService);
 
         $values = [
@@ -246,15 +252,15 @@ class PaymentControllerTest extends UnitTestCase
         $updateRegistration = false;
         $arguments = [&$values, &$updateRegistration, $mockRegistration, [], $this->subject];
 
-        $mockedSignalSlotDispatcher = $this->getAccessibleMock('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher', ['dispatch']);
+        $mockedSignalSlotDispatcher = $this->getAccessibleMock(Dispatcher::class, ['dispatch']);
         $mockedSignalSlotDispatcher->expects($this->once())->method('dispatch')->with(
-            'DERHANSEN\SfEventMgt\Controller\PaymentController',
+            PaymentController::class,
             'notifyActionProcessNotifyPaypal',
             $arguments
         );
         $this->subject->_set('signalSlotDispatcher', $mockedSignalSlotDispatcher);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $this->inject($this->subject, 'view', $view);
 
         $this->subject->notifyAction($mockRegistration, 'a-hmac');

--- a/Tests/Unit/Controller/PaymentControllerTest.php
+++ b/Tests/Unit/Controller/PaymentControllerTest.php
@@ -8,8 +8,8 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Controller;
  * LICENSE.txt file that was distributed with this source code.
  */
 
-use DERHANSEN\SfEventMgt\Domain\Model\Registration;
 use DERHANSEN\SfEventMgt\Controller\PaymentController;
+use DERHANSEN\SfEventMgt\Domain\Model\Registration;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;

--- a/Tests/Unit/Controller/UserRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/UserRegistrationControllerTest.php
@@ -8,8 +8,14 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Controller;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Controller\UserRegistrationController;
+use DERHANSEN\SfEventMgt\Domain\Model\Dto\UserRegistrationDemand;
+use DERHANSEN\SfEventMgt\Domain\Repository\RegistrationRepository;
 use DERHANSEN\SfEventMgt\Service\RegistrationService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
  * Test case for class DERHANSEN\SfEventMgt\Controller\UserRegistrationController
@@ -31,7 +37,7 @@ class UserRegistrationControllerTest extends UnitTestCase
     protected function setUp()
     {
         $this->subject = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\Controller\\UserRegistrationController',
+            UserRegistrationController::class,
             ['createUserRegistrationDemandObjectFromSettings'],
             [],
             '',
@@ -57,7 +63,7 @@ class UserRegistrationControllerTest extends UnitTestCase
      */
     public function createUserRegistrationDemandObjectFromSettingsTest()
     {
-        $mockController = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Controller\\UserRegistrationController')
+        $mockController = $this->getMockBuilder(UserRegistrationController::class)
             ->setMethods(['redirect', 'forward', 'addFlashMessage'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -70,14 +76,14 @@ class UserRegistrationControllerTest extends UnitTestCase
             'orderDirection' => 'asc',
         ];
 
-        $mockDemand = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Dto\\UserRegistrationDemand')
+        $mockDemand = $this->getMockBuilder(UserRegistrationDemand::class)
             ->getMock();
         $mockDemand->expects($this->at(0))->method('setDisplayMode')->with('all');
         $mockDemand->expects($this->at(1))->method('setStoragePage')->with(1);
         $mockDemand->expects($this->at(2))->method('setOrderField')->with('event.title');
         $mockDemand->expects($this->at(3))->method('setOrderDirection')->with('asc');
 
-        $objectManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Object\\ObjectManager')
+        $objectManager = $this->getMockBuilder(ObjectManager::class)
             ->disableOriginalConstructor()
             ->getMock();
         $objectManager->expects($this->any())->method('get')->will($this->returnValue($mockDemand));
@@ -94,12 +100,12 @@ class UserRegistrationControllerTest extends UnitTestCase
      */
     public function listActionFetchesRegistrationsFromRepositoryAndAssignsThemToView()
     {
-        $demand = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Dto\\UserRegistrationDemand')
+        $demand = $this->getMockBuilder(UserRegistrationDemand::class)
             ->setMethods(['setUser'])
             ->disableOriginalConstructor()
             ->getMock();
         $demand->expects($this->once())->method('setUser');
-        $registrations = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $registrations = $this->getMockBuilder(ObjectStorage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -117,7 +123,7 @@ class UserRegistrationControllerTest extends UnitTestCase
         $this->inject($this->subject, 'registrationService', $registrationServiceMock);
 
         $registrationRepository = $this->getMockBuilder(
-            'DERHANSEN\\SfEventMgt\\Domain\\Repository\\RegistrationRepository'
+            RegistrationRepository::class
         )->setMethods(['findRegistrationsByUserRegistrationDemand'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -125,7 +131,7 @@ class UserRegistrationControllerTest extends UnitTestCase
             ->will($this->returnValue($registrations));
         $this->inject($this->subject, 'registrationRepository', $registrationRepository);
 
-        $view = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface')->getMock();
+        $view = $this->getMockBuilder(ViewInterface::class)->getMock();
         $view->expects($this->at(0))->method('assign')->with('registrations', $registrations);
         $this->inject($this->subject, 'view', $view);
 

--- a/Tests/Unit/Domain/Model/CustomNotificationLogTest.php
+++ b/Tests/Unit/Domain/Model/CustomNotificationLogTest.php
@@ -8,8 +8,10 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\CustomNotificationLog;
 use DERHANSEN\SfEventMgt\Domain\Model\Event;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Domain\Model\BackendUser;
 
 /**
  * Test case for class \DERHANSEN\SfEventMgt\Domain\Model\CustomNotificationLog
@@ -30,7 +32,7 @@ class CustomNotificationLogTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\CustomNotificationLog();
+        $this->subject = new CustomNotificationLog();
     }
 
     /**
@@ -115,7 +117,7 @@ class CustomNotificationLogTest extends UnitTestCase
      */
     public function setCruserIdForBackendUserSetsBackendUser()
     {
-        $beuser = new \TYPO3\CMS\Beuser\Domain\Model\BackendUser();
+        $beuser = new BackendUser();
         $this->subject->setCruserId($beuser);
         $this->assertEquals($beuser, $this->subject->getCruserId());
     }

--- a/Tests/Unit/Domain/Model/Dto/CategoryDemandTest.php
+++ b/Tests/Unit/Domain/Model/Dto/CategoryDemandTest.php
@@ -8,6 +8,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model\Dto;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Dto\CategoryDemand;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -29,7 +30,7 @@ class CategoryDemandTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Dto\CategoryDemand();
+        $this->subject = new CategoryDemand();
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Dto/EventDemandTest.php
+++ b/Tests/Unit/Domain/Model/Dto/EventDemandTest.php
@@ -8,6 +8,8 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model\Dto;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Dto\EventDemand;
+use DERHANSEN\SfEventMgt\Domain\Model\Location;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -29,7 +31,7 @@ class EventDemandTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Dto\EventDemand();
+        $this->subject = new EventDemand();
     }
 
     /**
@@ -242,7 +244,7 @@ class EventDemandTest extends UnitTestCase
      */
     public function getLocationReturnsExpectedLocation()
     {
-        $location = new \DERHANSEN\SfEventMgt\Domain\Model\Location();
+        $location = new Location();
         $this->subject->setLocation($location);
         $this->assertSame(
             $location,

--- a/Tests/Unit/Domain/Model/Dto/ForeignRecordDemandTest.php
+++ b/Tests/Unit/Domain/Model/Dto/ForeignRecordDemandTest.php
@@ -8,6 +8,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model\Dto;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Dto\ForeignRecordDemand;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -29,7 +30,7 @@ class ForeignRecordDemandTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Dto\ForeignRecordDemand();
+        $this->subject = new ForeignRecordDemand();
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Dto/SearchDemandTest.php
+++ b/Tests/Unit/Domain/Model/Dto/SearchDemandTest.php
@@ -8,6 +8,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model\Dto;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -29,7 +30,7 @@ class SearchDemandTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand();
+        $this->subject = new SearchDemand();
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Dto/UserRegistrationDemandTest.php
+++ b/Tests/Unit/Domain/Model/Dto/UserRegistrationDemandTest.php
@@ -8,7 +8,9 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model\Dto;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Dto\UserRegistrationDemand;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
 
 /**
  * Test case for class \DERHANSEN\SfEventMgt\Domain\Model\Dto\UserRegistrationDemand
@@ -29,7 +31,7 @@ class UserRegistrationDemandTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Dto\UserRegistrationDemand();
+        $this->subject = new UserRegistrationDemand();
     }
 
     /**
@@ -177,7 +179,7 @@ class UserRegistrationDemandTest extends UnitTestCase
      */
     public function setUserSetsUser()
     {
-        $user = new \TYPO3\CMS\Extbase\Domain\Model\FrontendUser();
+        $user = new FrontendUser();
         $this->subject->setUser($user);
         $this->assertSame($this->subject->getUser(), $user);
     }

--- a/Tests/Unit/Domain/Model/EventTest.php
+++ b/Tests/Unit/Domain/Model/EventTest.php
@@ -8,9 +8,17 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Category;
+use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Domain\Model\Location;
+use DERHANSEN\SfEventMgt\Domain\Model\Organisator;
 use DERHANSEN\SfEventMgt\Domain\Model\PriceOption;
 use DERHANSEN\SfEventMgt\Domain\Model\Registration;
+use DERHANSEN\SfEventMgt\Domain\Model\Registration\Field;
+use DERHANSEN\SfEventMgt\Domain\Model\Speaker;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
  * Test case for class \DERHANSEN\SfEventMgt\Domain\Model\Event.
@@ -29,7 +37,7 @@ class EventTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $this->subject = new Event();
     }
 
     /**
@@ -284,7 +292,7 @@ class EventTest extends UnitTestCase
      */
     public function getCategoryReturnsInitialValueForCategory()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getCategory()
@@ -296,8 +304,8 @@ class EventTest extends UnitTestCase
      */
     public function setCategoryForObjectStorageContainingCategorySetsCategory()
     {
-        $category = new \DERHANSEN\SfEventMgt\Domain\Model\Category();
-        $objectStorageHoldingExactlyOneCategory = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $category = new Category();
+        $objectStorageHoldingExactlyOneCategory = new ObjectStorage();
         $objectStorageHoldingExactlyOneCategory->attach($category);
         $this->subject->setCategory($objectStorageHoldingExactlyOneCategory);
 
@@ -313,8 +321,8 @@ class EventTest extends UnitTestCase
      */
     public function addCategoryToObjectStorageHoldingCategory()
     {
-        $category = new \DERHANSEN\SfEventMgt\Domain\Model\Category();
-        $categoryObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $category = new Category();
+        $categoryObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -329,8 +337,8 @@ class EventTest extends UnitTestCase
      */
     public function removeCategoryFromObjectStorageHoldingCategory()
     {
-        $category = new \DERHANSEN\SfEventMgt\Domain\Model\Category();
-        $categoryObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $category = new Category();
+        $categoryObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -345,7 +353,7 @@ class EventTest extends UnitTestCase
      */
     public function getRegistrationReturnsInitialValueForRegistration()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getRegistration()
@@ -358,7 +366,7 @@ class EventTest extends UnitTestCase
     public function setRegistrationForObjectStorageContainingRegistrationSetsRegistration()
     {
         $registration = new Registration();
-        $objectStorageHoldingExactlyOneRegistration = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $objectStorageHoldingExactlyOneRegistration = new ObjectStorage();
         $objectStorageHoldingExactlyOneRegistration->attach($registration);
         $this->subject->setRegistration($objectStorageHoldingExactlyOneRegistration);
 
@@ -376,7 +384,7 @@ class EventTest extends UnitTestCase
     {
         $registration = new Registration();
         $registrationObjectStorageMock = $this->getMockBuilder(
-            'TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage'
+            ObjectStorage::class
         )->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -392,7 +400,7 @@ class EventTest extends UnitTestCase
     public function removeRegistrationFromObjectStorageHoldingRegistration()
     {
         $registration = new Registration();
-        $registrationObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $registrationObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -407,7 +415,7 @@ class EventTest extends UnitTestCase
      */
     public function getRegistrationWaitlistReturnsInitialValueForRegistrationWaitlist()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getRegistrationWaitlist()
@@ -420,7 +428,7 @@ class EventTest extends UnitTestCase
     public function setRegistrationWaitlistForObjectStorageContainingRegistrationSetsRegistrationWaitlist()
     {
         $registration = new Registration();
-        $objectStorageHoldingExactlyOneRegistration = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $objectStorageHoldingExactlyOneRegistration = new ObjectStorage();
         $objectStorageHoldingExactlyOneRegistration->attach($registration);
         $this->subject->setRegistrationWaitlist($objectStorageHoldingExactlyOneRegistration);
 
@@ -437,7 +445,7 @@ class EventTest extends UnitTestCase
     public function addRegistrationWaitlistToObjectStorageHoldingRegistrationWaitlist()
     {
         $registration = new Registration();
-        $registrationObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $registrationObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -453,7 +461,7 @@ class EventTest extends UnitTestCase
     public function removeRegistrationWaitlistFromObjectStorageHoldingRegistrationWaitlist()
     {
         $registration = new Registration();
-        $registrationObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $registrationObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -468,7 +476,7 @@ class EventTest extends UnitTestCase
      */
     public function getImageReturnsInitialValueForImage()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getImage()
@@ -480,8 +488,8 @@ class EventTest extends UnitTestCase
      */
     public function setImageForObjectStorageContainingImageSetsImage()
     {
-        $image = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
-        $objectStorageHoldingExactlyOneImage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $image = new FileReference();
+        $objectStorageHoldingExactlyOneImage = new ObjectStorage();
         $objectStorageHoldingExactlyOneImage->attach($image);
         $this->subject->setImage($objectStorageHoldingExactlyOneImage);
 
@@ -497,8 +505,8 @@ class EventTest extends UnitTestCase
      */
     public function addImageToObjectStorageHoldingImage()
     {
-        $image = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
-        $imageObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $image = new FileReference();
+        $imageObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -513,8 +521,8 @@ class EventTest extends UnitTestCase
      */
     public function removeImageFromObjectStorageHoldingImage()
     {
-        $image = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
-        $imageObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $image = new FileReference();
+        $imageObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -529,7 +537,7 @@ class EventTest extends UnitTestCase
      */
     public function getFilesReturnsInitialValueForfiles()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getFiles()
@@ -541,8 +549,8 @@ class EventTest extends UnitTestCase
      */
     public function setFilesForObjectStorageContainingFilesSetsFiles()
     {
-        $file = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
-        $objectStorageHoldingExactlyOneFile = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $file = new FileReference();
+        $objectStorageHoldingExactlyOneFile = new ObjectStorage();
         $objectStorageHoldingExactlyOneFile->attach($file);
         $this->subject->setFiles($objectStorageHoldingExactlyOneFile);
 
@@ -558,8 +566,8 @@ class EventTest extends UnitTestCase
      */
     public function addFilesToObjectStorageHoldingFiles()
     {
-        $files = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
-        $imageObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $files = new FileReference();
+        $imageObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -574,8 +582,8 @@ class EventTest extends UnitTestCase
      */
     public function removeFilesFromObjectStorageHoldingFiles()
     {
-        $files = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
-        $imageObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $files = new FileReference();
+        $imageObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -590,7 +598,7 @@ class EventTest extends UnitTestCase
      */
     public function getAdditionalImageReturnsInitialValueForfiles()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getAdditionalImage()
@@ -602,8 +610,8 @@ class EventTest extends UnitTestCase
      */
     public function setAdditionalImageForObjectStorageContainingFilesSetsFiles()
     {
-        $file = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
-        $objectStorageHoldingExactlyOneFile = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $file = new FileReference();
+        $objectStorageHoldingExactlyOneFile = new ObjectStorage();
         $objectStorageHoldingExactlyOneFile->attach($file);
         $this->subject->setAdditionalImage($objectStorageHoldingExactlyOneFile);
 
@@ -619,8 +627,8 @@ class EventTest extends UnitTestCase
      */
     public function addAdditionalImageToObjectStorageHoldingFiles()
     {
-        $files = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
-        $imageObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $files = new FileReference();
+        $imageObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -635,8 +643,8 @@ class EventTest extends UnitTestCase
      */
     public function removeAdditionalImageFromObjectStorageHoldingFiles()
     {
-        $files = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
-        $imageObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $files = new FileReference();
+        $imageObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -733,7 +741,7 @@ class EventTest extends UnitTestCase
         $this->subject->setEnableRegistration(true);
 
         $registration = new Registration();
-        $objectStorageHoldingExactlyOneRegistration = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $objectStorageHoldingExactlyOneRegistration = new ObjectStorage();
         $objectStorageHoldingExactlyOneRegistration->attach($registration);
         $this->subject->setRegistration($objectStorageHoldingExactlyOneRegistration);
 
@@ -753,7 +761,7 @@ class EventTest extends UnitTestCase
         $this->subject->setEnableWaitlist(true);
 
         $registration = new Registration();
-        $objectStorageHoldingExactlyOneRegistration = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $objectStorageHoldingExactlyOneRegistration = new ObjectStorage();
         $objectStorageHoldingExactlyOneRegistration->attach($registration);
         $this->subject->setRegistration($objectStorageHoldingExactlyOneRegistration);
 
@@ -820,7 +828,7 @@ class EventTest extends UnitTestCase
      */
     public function setLocationSetsLocation()
     {
-        $location = new \DERHANSEN\SfEventMgt\Domain\Model\Location();
+        $location = new Location();
         $this->subject->setLocation($location);
 
         $this->assertAttributeEquals(
@@ -1032,7 +1040,7 @@ class EventTest extends UnitTestCase
     {
         $this->subject->setMaxParticipants(10);
 
-        $registrationObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $registrationObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['count'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1123,7 +1131,7 @@ class EventTest extends UnitTestCase
      */
     public function setPhoneForStringSetsPhone()
     {
-        $organisator = new \DERHANSEN\SfEventMgt\Domain\Model\Organisator();
+        $organisator = new Organisator();
         $this->subject->setOrganisator($organisator);
 
         $this->assertAttributeEquals(
@@ -1300,7 +1308,7 @@ class EventTest extends UnitTestCase
      */
     public function getPriceOptionsReturnsInitialValueforObjectStorage()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getPriceOptions()
@@ -1313,7 +1321,7 @@ class EventTest extends UnitTestCase
      */
     public function setPriceOptionSetsPriceOptionForPriceOption()
     {
-        $priceOption = new \DERHANSEN\SfEventMgt\Domain\Model\PriceOption();
+        $priceOption = new PriceOption();
         $this->subject->setPriceOptions($priceOption);
         $this->assertEquals($priceOption, $this->subject->getPriceOptions());
     }
@@ -1324,8 +1332,8 @@ class EventTest extends UnitTestCase
      */
     public function addPriceOptionAddsPriceOptionForPriceOption()
     {
-        $priceOption = new \DERHANSEN\SfEventMgt\Domain\Model\PriceOption();
-        $priceOptionObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $priceOption = new PriceOption();
+        $priceOptionObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1341,8 +1349,8 @@ class EventTest extends UnitTestCase
      */
     public function removePriceOptionRemovesPriceOptionForPriceOption()
     {
-        $priceOption = new \DERHANSEN\SfEventMgt\Domain\Model\PriceOption();
-        $priceOptionObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $priceOption = new PriceOption();
+        $priceOptionObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1423,7 +1431,7 @@ class EventTest extends UnitTestCase
      */
     public function getRelatedReturnsInitialValueForObjectStorage()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getRelated()
@@ -1436,7 +1444,7 @@ class EventTest extends UnitTestCase
      */
     public function setRelatedSetsRelatedForRelated()
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
         $this->subject->setRelated($event);
         $this->assertEquals($event, $this->subject->getRelated());
     }
@@ -1447,8 +1455,8 @@ class EventTest extends UnitTestCase
      */
     public function addRelatedAddsRelatedForRelated()
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
-        $relatedObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $event = new Event();
+        $relatedObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1464,8 +1472,8 @@ class EventTest extends UnitTestCase
      */
     public function removeRelatedRemovesRelatedForRelated()
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
-        $relatedObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $event = new Event();
+        $relatedObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1540,7 +1548,7 @@ class EventTest extends UnitTestCase
      */
     public function getSpeakerReturnsInitialValueforObjectStorage()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getSpeaker()
@@ -1553,8 +1561,8 @@ class EventTest extends UnitTestCase
      */
     public function setSpeakerSetsSpeaker()
     {
-        $speaker = new \DERHANSEN\SfEventMgt\Domain\Model\Speaker();
-        $objectStorageWithSpeaker = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $speaker = new Speaker();
+        $objectStorageWithSpeaker = new ObjectStorage();
         $objectStorageWithSpeaker->attach($speaker);
         $this->subject->setSpeaker($objectStorageWithSpeaker);
         $this->assertEquals($objectStorageWithSpeaker, $this->subject->getSpeaker());
@@ -1566,8 +1574,8 @@ class EventTest extends UnitTestCase
      */
     public function addSpeakerAddsSpeaker()
     {
-        $speaker = new \DERHANSEN\SfEventMgt\Domain\Model\Speaker();
-        $speakerObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $speaker = new Speaker();
+        $speakerObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1583,8 +1591,8 @@ class EventTest extends UnitTestCase
      */
     public function removeSpeakerRemovesSpeaker()
     {
-        $speaker = new \DERHANSEN\SfEventMgt\Domain\Model\Speaker();
-        $speakerObjectStorageMock = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $speaker = new Speaker();
+        $speakerObjectStorageMock = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1600,7 +1608,7 @@ class EventTest extends UnitTestCase
      */
     public function getRegistrationFieldsReturnsInitialValueforObjectStorage()
     {
-        $newObjectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $newObjectStorage = new ObjectStorage();
         $this->assertEquals(
             $newObjectStorage,
             $this->subject->getRegistrationFields()
@@ -1613,8 +1621,8 @@ class EventTest extends UnitTestCase
      */
     public function setRegistrationFieldsSetsRegistrationFields()
     {
-        $registrationField = new \DERHANSEN\SfEventMgt\Domain\Model\Registration\Field();
-        $objectStorageWithRegistrationField = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $registrationField = new Field();
+        $objectStorageWithRegistrationField = new ObjectStorage();
         $objectStorageWithRegistrationField->attach($registrationField);
         $this->subject->setRegistrationFields($objectStorageWithRegistrationField);
         $this->assertEquals($objectStorageWithRegistrationField, $this->subject->getRegistrationFields());
@@ -1626,8 +1634,8 @@ class EventTest extends UnitTestCase
      */
     public function addRegistrationFieldsAddsRegistrationField()
     {
-        $registrationField = new \DERHANSEN\SfEventMgt\Domain\Model\Registration\Field();
-        $registrationFieldStorage = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $registrationField = new Field();
+        $registrationFieldStorage = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['attach'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1643,8 +1651,8 @@ class EventTest extends UnitTestCase
      */
     public function removeRegistrationFieldsRemovesRegistrationField()
     {
-        $registrationField = new \DERHANSEN\SfEventMgt\Domain\Model\Registration\Field();
-        $registrationFieldStorage = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage')
+        $registrationField = new Field();
+        $registrationFieldStorage = $this->getMockBuilder(ObjectStorage::class)
             ->setMethods(['detach'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/Tests/Unit/Domain/Model/LocationTest.php
+++ b/Tests/Unit/Domain/Model/LocationTest.php
@@ -8,6 +8,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Location;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -31,7 +32,7 @@ class LocationTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Location();
+        $this->subject = new Location();
     }
 
     /**

--- a/Tests/Unit/Domain/Model/OrganisatorTest.php
+++ b/Tests/Unit/Domain/Model/OrganisatorTest.php
@@ -8,7 +8,9 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Organisator;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 
 /**
  * Test case for class \DERHANSEN\SfEventMgt\Domain\Model\Organisator.
@@ -31,7 +33,7 @@ class OrganisatorTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Organisator();
+        $this->subject = new Organisator();
     }
 
     /**
@@ -156,7 +158,7 @@ class OrganisatorTest extends UnitTestCase
      */
     public function setImageForObjectStorageContainingImageSetsImage()
     {
-        $file = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
+        $file = new FileReference();
         $this->subject->setImage($file);
 
         $this->assertAttributeEquals(

--- a/Tests/Unit/Domain/Model/PriceOptionTest.php
+++ b/Tests/Unit/Domain/Model/PriceOptionTest.php
@@ -8,6 +8,8 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Domain\Model\PriceOption;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -31,7 +33,7 @@ class PriceOptionTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\PriceOption();
+        $this->subject = new PriceOption();
     }
 
     /**
@@ -116,7 +118,7 @@ class PriceOptionTest extends UnitTestCase
      */
     public function setEventForEventSetsEvent()
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
         $this->subject->setEvent($event);
         $this->assertEquals($event, $this->subject->getEvent());
     }

--- a/Tests/Unit/Domain/Model/Registration/FieldTest.php
+++ b/Tests/Unit/Domain/Model/Registration/FieldTest.php
@@ -9,6 +9,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model\Registration;
  */
 
 use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Domain\Model\Registration\Field;
 use DERHANSEN\SfEventMgt\Utility\FieldType;
 use DERHANSEN\SfEventMgt\Utility\FieldValueType;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
@@ -34,7 +35,7 @@ class FieldTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Registration\Field();
+        $this->subject = new Field();
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Registration/FieldValueTest.php
+++ b/Tests/Unit/Domain/Model/Registration/FieldValueTest.php
@@ -10,6 +10,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model\Registration;
 
 use DERHANSEN\SfEventMgt\Domain\Model\Registration;
 use DERHANSEN\SfEventMgt\Domain\Model\Registration\Field;
+use DERHANSEN\SfEventMgt\Domain\Model\Registration\FieldValue;
 use DERHANSEN\SfEventMgt\Utility\FieldValueType;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
@@ -34,7 +35,7 @@ class FieldValueTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Registration\FieldValue();
+        $this->subject = new FieldValue();
     }
 
     /**

--- a/Tests/Unit/Domain/Model/RegistrationTest.php
+++ b/Tests/Unit/Domain/Model/RegistrationTest.php
@@ -8,7 +8,10 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Domain\Model\Registration;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
 
 /**
  * Test case for class \DERHANSEN\SfEventMgt\Domain\Model\Registration.
@@ -29,7 +32,7 @@ class RegistrationTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $this->subject = new Registration();
     }
 
     /**
@@ -497,7 +500,7 @@ class RegistrationTest extends UnitTestCase
      */
     public function setEventForEventSetsEvent()
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
         $this->subject->setEvent($event);
         $this->assertEquals($event, $this->subject->getEvent());
     }
@@ -517,7 +520,7 @@ class RegistrationTest extends UnitTestCase
      */
     public function setMainRegistrationForRegistrationSetsRegistration()
     {
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration = new Registration();
         $this->subject->setMainRegistration($registration);
         $this->assertEquals($registration, $this->subject->getMainRegistration());
     }
@@ -685,7 +688,7 @@ class RegistrationTest extends UnitTestCase
      */
     public function setFeUserSetsFeUser()
     {
-        $user = new \TYPO3\CMS\Extbase\Domain\Model\FrontendUser();
+        $user = new FrontendUser();
         $this->subject->setFeUser($user);
         $this->assertSame($this->subject->getFeUser(), $user);
     }

--- a/Tests/Unit/Domain/Model/SpeakerTest.php
+++ b/Tests/Unit/Domain/Model/SpeakerTest.php
@@ -8,7 +8,9 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Domain\Model;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Speaker;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 
 /**
  * Test case for class \DERHANSEN\SfEventMgt\Domain\Model\Speaker.
@@ -31,7 +33,7 @@ class SpeakerTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Domain\Model\Speaker();
+        $this->subject = new Speaker();
     }
 
     /**
@@ -144,7 +146,7 @@ class SpeakerTest extends UnitTestCase
      */
     public function setImageForFileReferenceSetsImage()
     {
-        $image = new \TYPO3\CMS\Extbase\Domain\Model\FileReference();
+        $image = new FileReference();
         $this->subject->setImage($image);
 
         $this->assertAttributeEquals(

--- a/Tests/Unit/Evaluation/LatitudeEvaluatorTest.php
+++ b/Tests/Unit/Evaluation/LatitudeEvaluatorTest.php
@@ -8,6 +8,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Evaluation;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Evaluation\LatitudeEvaluator;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -31,7 +32,7 @@ class LatitudeEvaluatorTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Evaluation\LatitudeEvaluator();
+        $this->subject = new LatitudeEvaluator();
     }
 
     /**

--- a/Tests/Unit/Evaluation/LongitudeEvaluatorTest.php
+++ b/Tests/Unit/Evaluation/LongitudeEvaluatorTest.php
@@ -8,6 +8,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Evaluation;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Evaluation\LongitudeEvaluator;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -31,7 +32,7 @@ class LongitudeEvaluatorTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Evaluation\LongitudeEvaluator();
+        $this->subject = new LongitudeEvaluator();
     }
 
     /**

--- a/Tests/Unit/Payment/AbstractPaymentTest.php
+++ b/Tests/Unit/Payment/AbstractPaymentTest.php
@@ -8,6 +8,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Payment;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Payment\AbstractPayment;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -29,7 +30,7 @@ class AbstractPaymentTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = $this->getAccessibleMockForAbstractClass('DERHANSEN\\SfEventMgt\\Payment\\AbstractPayment');
+        $this->subject = $this->getAccessibleMockForAbstractClass(AbstractPayment::class);
     }
 
     /**

--- a/Tests/Unit/Service/CalendarServiceTest.php
+++ b/Tests/Unit/Service/CalendarServiceTest.php
@@ -9,7 +9,9 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Service;
  */
 
 use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Service\CalendarService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
  * Test case for class DERHANSEN\SfEventMgt\Service\CalendarServiceTest.
@@ -30,7 +32,7 @@ class CalendarServiceTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Service\CalendarService();
+        $this->subject = new CalendarService();
     }
 
     /**
@@ -91,7 +93,7 @@ class CalendarServiceTest extends UnitTestCase
             \DateTime::createFromFormat('d.m.Y', sprintf('2.%s.%s', 1, 2017))->setTime(12, 0, 0)
         ));
 
-        $events = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $events = new ObjectStorage();
         $events->attach($mockEvent);
 
         $calendarArray = $this->subject->getCalendarArray(1, 2017, mktime(0, 0, 0, 1, 1, 2017), 1, $events);
@@ -113,7 +115,7 @@ class CalendarServiceTest extends UnitTestCase
             \DateTime::createFromFormat('d.m.Y', sprintf('4.%s.%s', 1, 2017))->setTime(12, 0, 0)
         ));
 
-        $events = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $events = new ObjectStorage();
         $events->attach($mockEvent);
 
         $calendarArray = $this->subject->getCalendarArray(1, 2017, mktime(0, 0, 0, 1, 1, 2017), 1, $events);

--- a/Tests/Unit/Service/ExportServiceTest.php
+++ b/Tests/Unit/Service/ExportServiceTest.php
@@ -13,11 +13,13 @@ use DERHANSEN\SfEventMgt\Domain\Repository\RegistrationRepository;
 use DERHANSEN\SfEventMgt\Exception;
 use DERHANSEN\SfEventMgt\Service\ExportService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Core\Resource\Exception\InsufficientFileAccessPermissionsException;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\Folder;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
  * Class ExportServiceTest
@@ -145,7 +147,7 @@ class ExportServiceTest extends UnitTestCase
             $this->equalTo('wrongfield')
         )->will($this->returnValue(false));
 
-        $allRegistrations = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $allRegistrations = new ObjectStorage();
         $allRegistrations->attach($mockRegistration);
 
         $registrationRepository = $this->getMockBuilder(RegistrationRepository::class)
@@ -196,7 +198,7 @@ class ExportServiceTest extends UnitTestCase
             $this->equalTo('lastname')
         )->will($this->returnValue('Mustermann'));
 
-        $allRegistrations = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $allRegistrations = new ObjectStorage();
         $allRegistrations->attach($mockRegistration);
 
         $registrationRepository = $this->getMockBuilder(RegistrationRepository::class)
@@ -281,7 +283,7 @@ class ExportServiceTest extends UnitTestCase
     {
         $mockStorage = $this->getMockBuilder(ResourceStorage::class)->disableOriginalConstructor()->getMock();
         $mockStorage->expects($this->once())->method('getFolder')->will($this->throwException(
-            new \TYPO3\CMS\Core\Resource\Exception\InsufficientFileAccessPermissionsException()
+            new InsufficientFileAccessPermissionsException()
         ));
 
         $mockResourceFactory = $this->getMockBuilder(ResourceFactory::class)->disableOriginalConstructor()->getMock();

--- a/Tests/Unit/Service/ICalendarServiceTest.php
+++ b/Tests/Unit/Service/ICalendarServiceTest.php
@@ -16,8 +16,8 @@ use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Resource\StorageRepository;
-use TYPO3\CMS\Fluid\View\StandaloneView;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Fluid\View\StandaloneView;
 /**
  * Test case for class DERHANSEN\SfEventMgt\Service\ICalendarService.
  *

--- a/Tests/Unit/Service/ICalendarServiceTest.php
+++ b/Tests/Unit/Service/ICalendarServiceTest.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Resource\StorageRepository;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Fluid\View\StandaloneView;
+
 /**
  * Test case for class DERHANSEN\SfEventMgt\Service\ICalendarService.
  *

--- a/Tests/Unit/Service/ICalendarServiceTest.php
+++ b/Tests/Unit/Service/ICalendarServiceTest.php
@@ -10,10 +10,14 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Service;
 
 use DERHANSEN\SfEventMgt\Domain\Model\Event;
 use DERHANSEN\SfEventMgt\Exception;
+use DERHANSEN\SfEventMgt\Service\FluidStandaloneService;
 use DERHANSEN\SfEventMgt\Service\ICalendarService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
-
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 /**
  * Test case for class DERHANSEN\SfEventMgt\Service\ICalendarService.
  *
@@ -33,7 +37,7 @@ class ICalendarServiceTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Service\ICalendarService();
+        $this->subject = new ICalendarService();
     }
 
     /**
@@ -84,10 +88,10 @@ class ICalendarServiceTest extends UnitTestCase
             $this->returnValue('iCalendar Data')
         );
 
-        $mockFile = $this->getMockBuilder('TYPO3\\CMS\\Core\\Resource\\File')->disableOriginalConstructor()->getMock();
+        $mockFile = $this->getMockBuilder(File::class)->disableOriginalConstructor()->getMock();
         $mockFile->expects($this->once())->method('setContents')->with('iCalendar Data');
 
-        $mockStorageRepository = $this->getMockBuilder('TYPO3\CMS\Core\Resource\StorageRepository')
+        $mockStorageRepository = $this->getMockBuilder(StorageRepository::class)
             ->setMethods(['getFolder', 'createFile', 'dumpFileContents'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -117,7 +121,7 @@ class ICalendarServiceTest extends UnitTestCase
 
         $mockEvent = $this->getMockBuilder(Event::class)->getMock();
 
-        $iCalendarView = $this->getMockBuilder('TYPO3\\CMS\\Fluid\\View\\StandaloneView')
+        $iCalendarView = $this->getMockBuilder(StandaloneView::class)
             ->disableOriginalConstructor()
             ->getMock();
         $iCalendarView->expects($this->once())->method('setFormat')->with('txt');
@@ -126,13 +130,13 @@ class ICalendarServiceTest extends UnitTestCase
             'typo3Host' => 'myhostname.tld'
         ]);
 
-        $objectManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Object\\ObjectManager')
+        $objectManager = $this->getMockBuilder(ObjectManager::class)
             ->disableOriginalConstructor()
             ->getMock();
         $objectManager->expects($this->once())->method('get')->will($this->returnValue($iCalendarView));
         $this->inject($this->subject, 'objectManager', $objectManager);
 
-        $fluidStandaloneService = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Service\\FluidStandaloneService')
+        $fluidStandaloneService = $this->getMockBuilder(FluidStandaloneService::class)
             ->getMock();
         $fluidStandaloneService->expects($this->any())->method('getTemplateFolders')->will($this->returnValue([]));
         $this->inject($this->subject, 'fluidStandaloneService', $fluidStandaloneService);

--- a/Tests/Unit/Service/Notification/AttachmentServiceTest.php
+++ b/Tests/Unit/Service/Notification/AttachmentServiceTest.php
@@ -8,12 +8,16 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Service\Notification;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Domain\Model\Registration;
 use DERHANSEN\SfEventMgt\Service\ICalendarService;
+use DERHANSEN\SfEventMgt\Service\Notification\AttachmentService;
 use DERHANSEN\SfEventMgt\Utility\MessageRecipient;
 use DERHANSEN\SfEventMgt\Utility\MessageType;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 
 /**
  * Test case for class DERHANSEN\SfEventMgt\Service\Notification\AttachmentService.
@@ -34,7 +38,7 @@ class AttachmentServiceTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Service\Notification\AttachmentService();
+        $this->subject = new AttachmentService();
     }
 
     /**
@@ -126,7 +130,7 @@ class AttachmentServiceTest extends UnitTestCase
         $settingsPath,
         $expected
     ) {
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration = new Registration();
 
         $settings = ['notification' => [
             $settingsPath => [
@@ -151,15 +155,15 @@ class AttachmentServiceTest extends UnitTestCase
      */
     public function getAttachmentsReturnsAttachmentsFromEventPropertyWithObjectStorage()
     {
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $registration = new Registration();
+        $event = new Event();
 
         $mockFile1 = $this->getMockBuilder(File::class)
             ->setMethods(['getForLocalProcessing'])
             ->disableOriginalConstructor()
             ->getMock();
         $mockFile1->expects($this->any())->method('getForLocalProcessing')->will($this->returnValue('/path/to/somefile.pdf'));
-        $mockFileRef1 = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Domain\\Model\\FileReference')
+        $mockFileRef1 = $this->getMockBuilder(FileReference::class)
             ->setMethods(['getOriginalResource'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -170,7 +174,7 @@ class AttachmentServiceTest extends UnitTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $mockFile2->expects($this->any())->method('getForLocalProcessing')->will($this->returnValue('/path/to/anotherfile.pdf'));
-        $mockFileRef2 = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Domain\\Model\\FileReference')
+        $mockFileRef2 = $this->getMockBuilder(FileReference::class)
             ->setMethods(['getOriginalResource'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -212,20 +216,20 @@ class AttachmentServiceTest extends UnitTestCase
      */
     public function getAttachmentsReturnsAttachmentsFromEventPropertyWithFileReference()
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
 
         $mockFile = $this->getMockBuilder(File::class)
             ->setMethods(['getForLocalProcessing'])
             ->disableOriginalConstructor()
             ->getMock();
         $mockFile->expects($this->any())->method('getForLocalProcessing')->will($this->returnValue('/path/to/somefile.pdf'));
-        $mockFileRef = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Domain\\Model\\FileReference')
+        $mockFileRef = $this->getMockBuilder(FileReference::class)
             ->setMethods(['getOriginalResource'])
             ->disableOriginalConstructor()
             ->getMock();
         $mockFileRef->expects($this->any())->method('getOriginalResource')->will($this->returnValue($mockFile));
 
-        $mockRegistration = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Registration')
+        $mockRegistration = $this->getMockBuilder(Registration::class)
             ->setMethods(['getEvent', '_hasProperty', '_getProperty'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -263,7 +267,7 @@ class AttachmentServiceTest extends UnitTestCase
      */
     public function getICalAttachmentReturnsAFilenameIfICalFileEnabled()
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
 
         $settings = ['notification' => [
             'registrationNew' => [
@@ -275,7 +279,7 @@ class AttachmentServiceTest extends UnitTestCase
             ]
         ]];
 
-        $mockRegistration = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Domain\\Model\\Registration')
+        $mockRegistration = $this->getMockBuilder(Registration::class)
             ->setMethods(['getEvent', '_hasProperty', '_getProperty'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/Tests/Unit/Service/NotificationServiceTest.php
+++ b/Tests/Unit/Service/NotificationServiceTest.php
@@ -8,6 +8,8 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Service;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Domain\Model\Organisator;
 use DERHANSEN\SfEventMgt\Domain\Model\Registration;
 use DERHANSEN\SfEventMgt\Domain\Repository\CustomNotificationLogRepository;
 use DERHANSEN\SfEventMgt\Domain\Repository\RegistrationRepository;
@@ -17,6 +19,7 @@ use DERHANSEN\SfEventMgt\Service\Notification\AttachmentService;
 use DERHANSEN\SfEventMgt\Service\NotificationService;
 use DERHANSEN\SfEventMgt\Utility\MessageType;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
 
 /**
@@ -38,7 +41,7 @@ class NotificationServiceTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Service\NotificationService();
+        $this->subject = new NotificationService();
     }
 
     /**
@@ -84,8 +87,8 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendUserMessageReturnsFalseIfIgnoreNotificationsSet($messageType)
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $event = new Event();
+        $registration = new Registration();
         $registration->setEmail('valid@email.tld');
         $registration->setIgnoreNotifications(true);
 
@@ -112,8 +115,8 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendUserMessageReturnsFalseIfSendFailed($messageType)
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $event = new Event();
+        $registration = new Registration();
         $registration->setEmail('valid@email.tld');
 
         $settings = ['notification' => ['senderEmail' => 'valid@email.tld']];
@@ -149,8 +152,8 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendUserMessageReturnsTrueIfSendSuccessful($messageType)
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $event = new Event();
+        $registration = new Registration();
         $registration->setEmail('valid@email.tld');
 
         $settings = ['notification' => ['senderEmail' => 'valid@email.tld']];
@@ -187,8 +190,8 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendAdminNewRegistrationMessageReturnsFalseIfSendFailed($messageType)
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $event = new Event();
+        $registration = new Registration();
 
         $settings = [
             'notification' => [
@@ -239,8 +242,8 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendAdminNewRegistrationMessageReturnsTrueIfSendSuccessful($messageType)
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $event = new Event();
+        $registration = new Registration();
 
         $settings = [
             'notification' => [
@@ -281,10 +284,10 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendAdminMessageDoesNotSendEmailIfNotifyAdminAndNotifyOrganiserIsFalse($messageType)
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
         $event->setNotifyAdmin(false);
         $event->setNotifyOrganisator(false);
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration = new Registration();
 
         $settings = [
             'notification' => [
@@ -308,12 +311,12 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendAdminMessageSendsEmailToOrganisatorIfConfigured($messageType)
     {
-        $organisator = new \DERHANSEN\SfEventMgt\Domain\Model\Organisator();
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $organisator = new Organisator();
+        $event = new Event();
         $event->setNotifyAdmin(false);
         $event->setNotifyOrganisator(true);
         $event->setOrganisator($organisator);
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration = new Registration();
 
         $settings = [
             'notification' => [
@@ -352,8 +355,8 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendAdminMessageUsesRegistrationDataAsSenderIfConfigured()
     {
-        $organisator = new \DERHANSEN\SfEventMgt\Domain\Model\Organisator();
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $organisator = new Organisator();
+        $event = new Event();
         $event->setNotifyAdmin(false);
         $event->setNotifyOrganisator(true);
         $event->setOrganisator($organisator);
@@ -403,8 +406,8 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendMultipleAdminNewRegistrationMessageReturnsTrueIfSendSuccessful($messageType)
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $event = new Event();
+        $registration = new Registration();
 
         $settings = [
             'notification' => [
@@ -443,8 +446,8 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendUserMessageReturnsFalseIfNoCustomMessageGiven()
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $event = new Event();
+        $registration = new Registration();
         $registration->setEmail('valid@email.tld');
 
         $settings = ['notification' => ['senderEmail' => 'valid@email.tld']];
@@ -493,14 +496,14 @@ class NotificationServiceTest extends UnitTestCase
         $confirmed,
         $ignoreNotifications
     ) {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
 
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration = new Registration();
         $registration->setConfirmed($confirmed);
         $registration->setIgnoreNotifications($ignoreNotifications);
 
         /** @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage $registrations */
-        $registrations = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $registrations = new ObjectStorage();
         $registrations->attach($registration);
 
         $mockNotificationService = $this->getMockBuilder(NotificationService::class)
@@ -530,20 +533,20 @@ class NotificationServiceTest extends UnitTestCase
      */
     public function sendCustomNotificationReturnsExpectedAmountOfNotificationsSent()
     {
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
 
-        $registration1 = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration1 = new Registration();
         $registration1->setConfirmed(false);
-        $registration2 = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration2 = new Registration();
         $registration2->setConfirmed(true);
-        $registration3 = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration3 = new Registration();
         $registration3->setConfirmed(true);
-        $registration4 = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration4 = new Registration();
         $registration4->setConfirmed(true);
         $registration4->setIgnoreNotifications(true);
 
         /** @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage $registrations */
-        $registrations = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $registrations = new ObjectStorage();
         $registrations->attach($registration1);
         $registrations->attach($registration2);
         $registrations->attach($registration3);
@@ -580,7 +583,7 @@ class NotificationServiceTest extends UnitTestCase
         $mockLogRepo->expects($this->once())->method('add');
         $this->inject($this->subject, 'customNotificationLogRepository', $mockLogRepo);
 
-        $event = new \DERHANSEN\SfEventMgt\Domain\Model\Event();
+        $event = new Event();
         $this->subject->createCustomNotificationLogentry($event, 'A description', 1);
     }
 }

--- a/Tests/Unit/Service/PaymentServiceTest.php
+++ b/Tests/Unit/Service/PaymentServiceTest.php
@@ -34,11 +34,11 @@ class PaymentServiceTest extends UnitTestCase
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['sf_event_mgt']['paymentMethods'] = [
             'invoice' => [
-                'class' => 'DERHANSEN\\SfEventMgt\\Payment\\Invoice',
+                'class' => Invoice::class,
                 'extkey' => 'sf_event_mgt'
             ],
             'transfer' => [
-                'class' => 'DERHANSEN\\SfEventMgt\\Payment\\Transfer',
+                'class' => Transfer::class,
                 'extkey' => 'sf_event_mgt'
             ]
         ];
@@ -200,7 +200,7 @@ class PaymentServiceTest extends UnitTestCase
     public function paymentActionEnabledForCustomPaymentMethodReturnsExpectedResult($action, $expected)
     {
         $mockPaymentInstance = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\Payment\\Invoice',
+            Invoice::class,
             [
                 'isRedirectEnabled',
                 'isSuccessLinkEnabled',

--- a/Tests/Unit/Service/RegistrationServiceTest.php
+++ b/Tests/Unit/Service/RegistrationServiceTest.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Extbase\Domain\Repository\FrontendUserRepository;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
+
 /**
  * Test case for class DERHANSEN\SfEventMgt\Service\RegistrationService.
  *

--- a/Tests/Unit/Service/RegistrationServiceTest.php
+++ b/Tests/Unit/Service/RegistrationServiceTest.php
@@ -9,15 +9,18 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Service;
  */
 
 use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\Domain\Model\Invoice;
 use DERHANSEN\SfEventMgt\Domain\Model\Registration;
 use DERHANSEN\SfEventMgt\Domain\Repository\RegistrationRepository;
 use DERHANSEN\SfEventMgt\Service\PaymentService;
+use DERHANSEN\SfEventMgt\Service\RegistrationService;
 use DERHANSEN\SfEventMgt\Utility\RegistrationResult;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\Domain\Repository\FrontendUserRepository;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
-
 /**
  * Test case for class DERHANSEN\SfEventMgt\Service\RegistrationService.
  *
@@ -37,7 +40,7 @@ class RegistrationServiceTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Service\RegistrationService();
+        $this->subject = new RegistrationService();
     }
 
     /**
@@ -62,7 +65,7 @@ class RegistrationServiceTest extends UnitTestCase
         $registration->expects($this->once())->method('setHidden')->with(true);
 
         /** @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage $registrations */
-        $registrations = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $registrations = new ObjectStorage();
         $registrations->attach($registration);
 
         $registrationRepository = $this->getMockBuilder(RegistrationRepository::class)
@@ -86,7 +89,7 @@ class RegistrationServiceTest extends UnitTestCase
         $registration = $this->getMockBuilder(Registration::class)->disableOriginalConstructor()->getMock();
 
         /** @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage $registrations */
-        $registrations = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $registrations = new ObjectStorage();
         $registrations->attach($registration);
 
         $registrationRepository = $this->getMockBuilder(RegistrationRepository::class)
@@ -145,7 +148,7 @@ class RegistrationServiceTest extends UnitTestCase
         $foundRegistration2->expects($this->any())->method('setConfirmed');
 
         /** @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage $registrations */
-        $registrations = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $registrations = new ObjectStorage();
         $registrations->attach($foundRegistration1);
         $registrations->attach($foundRegistration2);
 
@@ -171,7 +174,7 @@ class RegistrationServiceTest extends UnitTestCase
         $foundRegistration2 = $this->getMockBuilder(Registration::class)->disableOriginalConstructor()->getMock();
 
         /** @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage $registrations */
-        $registrations = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $registrations = new ObjectStorage();
         $registrations->attach($foundRegistration1);
         $registrations->attach($foundRegistration2);
 
@@ -542,9 +545,9 @@ class RegistrationServiceTest extends UnitTestCase
         $GLOBALS['TSFE']->fe_user->user = [];
         $GLOBALS['TSFE']->fe_user->user['uid'] = 1;
 
-        $feUser = new \TYPO3\CMS\Extbase\Domain\Model\FrontendUser();
+        $feUser = new FrontendUser();
 
-        $mockFeUserRepository = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Domain\\Repository\\FrontendUserRepository')
+        $mockFeUserRepository = $this->getMockBuilder(FrontendUserRepository::class)
             ->setMethods(['findByUid'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -797,7 +800,7 @@ class RegistrationServiceTest extends UnitTestCase
         $mockRegistration->expects($this->once())->method('getPaymentMethod');
 
         // Payment mock object with redirect enabled
-        $mockInvoice = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Payment\\Invoice')
+        $mockInvoice = $this->getMockBuilder(Invoice::class)
             ->setMethods(['isRedirectEnabled'])
             ->getMock();
         $mockInvoice->expects($this->once())->method('isRedirectEnabled')->will($this->returnValue(true));

--- a/Tests/Unit/Service/SettingsServiceTest.php
+++ b/Tests/Unit/Service/SettingsServiceTest.php
@@ -8,6 +8,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Service;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Service\SettingsService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -29,7 +30,7 @@ class SettingsServiceTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Service\SettingsService();
+        $this->subject = new SettingsService();
     }
 
     /**

--- a/Tests/Unit/Service/UtilityServiceTest.php
+++ b/Tests/Unit/Service/UtilityServiceTest.php
@@ -9,6 +9,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Service;
  */
 
 use DERHANSEN\SfEventMgt\Service\SettingsService;
+use DERHANSEN\SfEventMgt\Service\UtilityService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TYPO3\CMS\Extbase\Service\CacheService;
 
@@ -31,7 +32,7 @@ class UtilityServiceTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \DERHANSEN\SfEventMgt\Service\UtilityService();
+        $this->subject = new UtilityService();
     }
 
     /**

--- a/Tests/Unit/Validation/Validator/RegistrationValidatorTest.php
+++ b/Tests/Unit/Validation/Validator/RegistrationValidatorTest.php
@@ -19,7 +19,6 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Validation\Validator\BooleanValidator;
 use TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator;
 
-
 /**
  * Test case for class DERHANSEN\SfEventMgt\Validation\Validator\RegistrationValidator.
  *

--- a/Tests/Unit/Validation/Validator/RegistrationValidatorTest.php
+++ b/Tests/Unit/Validation/Validator/RegistrationValidatorTest.php
@@ -8,9 +8,17 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\Validation\Validator;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\Domain\Model\Registration;
+use DERHANSEN\SfEventMgt\Validation\Validator\RecaptchaValidator;
+use DERHANSEN\SfEventMgt\Validation\Validator\RegistrationValidator;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Error\Error;
+use TYPO3\CMS\Extbase\Error\Result;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Validation\Validator\BooleanValidator;
+use TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator;
+
 
 /**
  * Test case for class DERHANSEN\SfEventMgt\Validation\Validator\RegistrationValidator.
@@ -27,7 +35,7 @@ class RegistrationValidatorTest extends UnitTestCase
     /**
      * @var string
      */
-    protected $validatorClassName = 'DERHANSEN\\SfEventMgt\\Validation\\Validator\\RegistrationValidator';
+    protected $validatorClassName = RegistrationValidator::class;
 
     /**
      * Setup
@@ -77,7 +85,7 @@ class RegistrationValidatorTest extends UnitTestCase
      */
     public function validatorReturnsTrueWhenArgumentsMissing($settings, $fields, $expected)
     {
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration = new Registration();
         $registration->setFirstname('John');
         $registration->setLastname('Doe');
         $registration->setEmail('email@domain.tld');
@@ -165,7 +173,7 @@ class RegistrationValidatorTest extends UnitTestCase
      */
     public function validatorReturnsExpectedResults($settings, $fields, $hasErrors, $expected)
     {
-        $registration = new \DERHANSEN\SfEventMgt\Domain\Model\Registration();
+        $registration = new Registration();
         $registration->setFirstname('John');
         $registration->setLastname('Doe');
         $registration->setEmail('email@domain.tld');
@@ -185,31 +193,31 @@ class RegistrationValidatorTest extends UnitTestCase
         $this->inject($this->validator, 'configurationManager', $configurationManager);
 
         // Inject the object manager
-        $validationError = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Error\\Error')
+        $validationError = $this->getMockBuilder(Error::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $validationResult = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Error\\Result')->getMock();
+        $validationResult = $this->getMockBuilder(Result::class)->getMock();
         $validationResult->expects($this->any())->method('hasErrors')->will($this->returnValue($hasErrors));
         $validationResult->expects($this->any())->method('getErrors')->will(
             $this->returnValue([$validationError])
         );
 
-        $notEmptyValidator = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Validation\\Validator\\NotEmptyValidator')
+        $notEmptyValidator = $this->getMockBuilder(NotEmptyValidator::class)
             ->disableOriginalConstructor()
             ->getMock();
         $notEmptyValidator->expects($this->any())->method('validate')->will($this->returnValue(
             $validationResult
         ));
 
-        $booleanValidator = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Validation\\Validator\\BooleanValidator')
+        $booleanValidator = $this->getMockBuilder(BooleanValidator::class)
             ->disableOriginalConstructor()
             ->getMock();
         $booleanValidator->expects($this->any())->method('validate')->will($this->returnValue(
             $validationResult
         ));
 
-        $recaptchaValidator = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\Validation\\Validator\\RecaptchaValidator')
+        $recaptchaValidator = $this->getMockBuilder(RecaptchaValidator::class)
             ->disableOriginalConstructor()
             ->getMock();
         $recaptchaValidator->expects($this->any())->method('validate')->will($this->returnValue(
@@ -239,13 +247,13 @@ class RegistrationValidatorTest extends UnitTestCase
         return [
             'string' => [
                 'string',
-                new \TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator(),
-                '\TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator'
+                new NotEmptyValidator(),
+                NotEmptyValidator::class
             ],
             'boolean' => [
                 'boolean',
-                new \TYPO3\CMS\Extbase\Validation\Validator\BooleanValidator(),
-                '\TYPO3\CMS\Extbase\Validation\Validator\BooleanValidator'
+                new BooleanValidator(),
+                BooleanValidator::class
             ]
         ];
     }

--- a/Tests/Unit/ViewHelpers/Event/SimultaneousRegistrationsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Event/SimultaneousRegistrationsViewHelperTest.php
@@ -9,6 +9,7 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\ViewHelpers\Event;
  */
 
 use DERHANSEN\SfEventMgt\Domain\Model\Event;
+use DERHANSEN\SfEventMgt\ViewHelpers\Event\SimultaneousRegistrationsViewHelper;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 /**
@@ -32,7 +33,7 @@ class SimultaneousRegistrationsViewHelperTest extends UnitTestCase
      */
     protected function setUp()
     {
-        $this->viewhelper = new \DERHANSEN\SfEventMgt\ViewHelpers\Event\SimultaneousRegistrationsViewHelper();
+        $this->viewhelper = new SimultaneousRegistrationsViewHelper();
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/Format/ICalendarDateViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/ICalendarDateViewHelperTest.php
@@ -64,7 +64,7 @@ class ICalendarDateViewHelperTest extends UnitTestCase
      */
     public function viewHelperRendersChildrenIfNoValueGiven()
     {
-        $viewHelper = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\ViewHelpers\\Format\\ICalendarDateViewHelper')
+        $viewHelper = $this->getMockBuilder(ICalendarDateViewHelper::class)
             ->setMethods(['renderChildren'])
             ->getMock();
         $viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(new \DateTime('@1425234250')));

--- a/Tests/Unit/ViewHelpers/Format/ICalendarDescriptionViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/ICalendarDescriptionViewHelperTest.php
@@ -80,7 +80,7 @@ class ICalendarDescriptionViewHelperTest extends UnitTestCase
      */
     public function viewHelperRendersChildrenIfNoValueGiven()
     {
-        $viewHelper = $this->getMockBuilder('DERHANSEN\\SfEventMgt\\ViewHelpers\\Format\\ICalendarDescriptionViewHelper')
+        $viewHelper = $this->getMockBuilder(ICalendarDescriptionViewHelper::class)
             ->setMethods(['renderChildren'])
             ->getMock();
         $viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('Just some text'));

--- a/Tests/Unit/ViewHelpers/PrefillViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/PrefillViewHelperTest.php
@@ -10,6 +10,9 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\ViewHelpers;
 
 use DERHANSEN\SfEventMgt\ViewHelpers\PrefillViewHelper;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
+use TYPO3\CMS\Extbase\Mvc\Request;
 
 /**
  * Test case for prefill viewhelper
@@ -35,7 +38,7 @@ class PrefillViewHelperTest extends UnitTestCase
      */
     public function viewReturnsCurrentFieldValueIfValueInGPAvailable()
     {
-        \TYPO3\CMS\Core\Utility\GeneralUtility::_GETset(
+        GeneralUtility::_GETset(
             [
                 'tx_sfeventmgt_pievent' => [
                     'registration' => ['fieldname' => 'Existing Value']
@@ -99,13 +102,13 @@ class PrefillViewHelperTest extends UnitTestCase
             'first_name' => 'John'
         ];
 
-        $mockRequest = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Request')
+        $mockRequest = $this->getMockBuilder(Request::class)
             ->setMethods(['getOriginalRequest'])
             ->disableOriginalConstructor()
             ->getMock();
         $mockRequest->expects($this->once())->method('getOriginalRequest')->will($this->returnValue(null));
 
-        $mockControllerContext = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ControllerContext')
+        $mockControllerContext = $this->getMockBuilder(ControllerContext::class)
             ->setMethods(['getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -114,7 +117,7 @@ class PrefillViewHelperTest extends UnitTestCase
         );
 
         $viewHelper = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\ViewHelpers\\PrefillViewHelper',
+            PrefillViewHelper::class,
             ['dummy'],
             [],
             '',
@@ -138,13 +141,13 @@ class PrefillViewHelperTest extends UnitTestCase
             'first_name' => 'John',
             'last_name' => 'Doe'
         ];
-        $mockRequest = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Request')
+        $mockRequest = $this->getMockBuilder(Request::class)
             ->setMethods(['getOriginalRequest'])
             ->disableOriginalConstructor()
             ->getMock();
         $mockRequest->expects($this->once())->method('getOriginalRequest')->will($this->returnValue(null));
 
-        $mockControllerContext = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ControllerContext')
+        $mockControllerContext = $this->getMockBuilder(ControllerContext::class)
             ->setMethods(['getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -153,7 +156,7 @@ class PrefillViewHelperTest extends UnitTestCase
         );
 
         $viewHelper = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\ViewHelpers\\PrefillViewHelper',
+            PrefillViewHelper::class,
             ['dummy'],
             [],
             '',
@@ -184,19 +187,19 @@ class PrefillViewHelperTest extends UnitTestCase
             ]
         ];
 
-        $mockOriginalRequest = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Request')
+        $mockOriginalRequest = $this->getMockBuilder(Request::class)
             ->setMethods(['getArguments'])
             ->disableOriginalConstructor()
             ->getMock();
         $mockOriginalRequest->expects($this->once())->method('getArguments')->will($this->returnValue($arguments));
 
-        $mockRequest = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Request')
+        $mockRequest = $this->getMockBuilder(Request::class)
             ->setMethods(['getOriginalRequest'])
             ->disableOriginalConstructor()
             ->getMock();
         $mockRequest->expects($this->once())->method('getOriginalRequest')->will($this->returnValue($mockOriginalRequest));
 
-        $mockControllerContext = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ControllerContext')
+        $mockControllerContext = $this->getMockBuilder(ControllerContext::class)
             ->setMethods(['getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -205,7 +208,7 @@ class PrefillViewHelperTest extends UnitTestCase
         );
 
         $viewHelper = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\ViewHelpers\\PrefillViewHelper',
+            PrefillViewHelper::class,
             ['dummy'],
             [],
             '',

--- a/Tests/Unit/ViewHelpers/Uri/PageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/PageViewHelperTest.php
@@ -8,7 +8,12 @@ namespace DERHANSEN\SfEventMgt\Tests\Unit\ViewHelpers;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use DERHANSEN\SfEventMgt\ViewHelpers\Uri\PageViewHelper;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Core\TimeTracker\TimeTracker;
+use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Test case for uri.page viewhelper
@@ -25,7 +30,7 @@ class PageViewHelperTest extends UnitTestCase
      */
     public function viewHelperCallsBuildFrontendUri()
     {
-        $mockUriBuilderFrontendUri = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderFrontendUri = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['buildFrontendUri'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -33,7 +38,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue('The Uri')
         );
 
-        $mockUriBuilderQueryStringMethod = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderQueryStringMethod = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setAddQueryStringMethod'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -42,7 +47,7 @@ class PageViewHelperTest extends UnitTestCase
         );
 
         $mockUriBuilderExcludedFromQueryString = $this->getMockBuilder(
-            'TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder'
+            UriBuilder::class
         )->setMethods(['setArgumentsToBeExcludedFromQueryString'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -50,7 +55,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderQueryStringMethod)
         );
 
-        $mockUriBuilderQueryString = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderQueryString = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setAddQueryString'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -58,7 +63,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderExcludedFromQueryString)
         );
 
-        $mockUriBuilderAbsoluteUri = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderAbsoluteUri = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setCreateAbsoluteUri'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -66,7 +71,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderQueryString)
         );
 
-        $mockUriBuilderArguments = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderArguments = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setArguments'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -74,7 +79,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderAbsoluteUri)
         );
 
-        $mockUriBuilderRestrictedPages = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderRestrictedPages = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setLinkAccessRestrictedPages'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -82,7 +87,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderArguments)
         );
 
-        $mockUriBuilderSection = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderSection = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setSection'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -90,7 +95,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderRestrictedPages)
         );
 
-        $mockUriBuilderCacheHash = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderCacheHash = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setUseCacheHash'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -98,7 +103,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderSection)
         );
 
-        $mockUriBuilderNoCache = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderNoCache = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setNoCache'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -106,7 +111,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderCacheHash)
         );
 
-        $mockUriBuilderPageType = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderPageType = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setTargetPageType'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -114,7 +119,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderNoCache)
         );
 
-        $mockUriBuilderPageUid = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder')
+        $mockUriBuilderPageUid = $this->getMockBuilder(UriBuilder::class)
             ->setMethods(['setTargetPageUid'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -122,7 +127,7 @@ class PageViewHelperTest extends UnitTestCase
             $this->returnValue($mockUriBuilderPageType)
         );
 
-        $mockControllerContext = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ControllerContext')
+        $mockControllerContext = $this->getMockBuilder(ControllerContext::class)
             ->setMethods(['getUriBuilder'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -131,7 +136,7 @@ class PageViewHelperTest extends UnitTestCase
         );
 
         $viewHelper = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\ViewHelpers\\Uri\\PageViewHelper',
+            PageViewHelper::class,
             ['buildTsfe'],
             [],
             '',
@@ -152,13 +157,13 @@ class PageViewHelperTest extends UnitTestCase
      */
     public function buildTsfeWithoutTtSet()
     {
-        $mockTimeTracker = $this->getMockBuilder('TYPO3\\CMS\\Core\\TimeTracker\\TimeTracker')
+        $mockTimeTracker = $this->getMockBuilder(TimeTracker::class)
             ->setMethods(['start'])
             ->disableOriginalConstructor()
             ->getMock();
         $mockTimeTracker->expects($this->once())->method('start');
 
-        $mockTsfe = $this->getMockBuilder('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController')
+        $mockTsfe = $this->getMockBuilder(TypoScriptFrontendController::class)
             ->setMethods(
                 [
                     'initFEuser',
@@ -176,7 +181,7 @@ class PageViewHelperTest extends UnitTestCase
         $mockTsfe->expects($this->once())->method('getConfigArray');
 
         $viewHelper = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\ViewHelpers\\Uri\\PageViewHelper',
+            PageViewHelper::class,
             ['getTsfeInstance', 'getTimeTrackerInstance'],
             [],
             '',
@@ -196,7 +201,7 @@ class PageViewHelperTest extends UnitTestCase
     public function buildTsfeWithTtSet()
     {
         $GLOBALS['TT'] = new \stdClass();
-        $mockTsfe = $this->getMockBuilder('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController')
+        $mockTsfe = $this->getMockBuilder(TypoScriptFrontendController::class)
             ->setMethods(
                 [
                     'initFEuser',
@@ -214,7 +219,7 @@ class PageViewHelperTest extends UnitTestCase
         $mockTsfe->expects($this->once())->method('getConfigArray');
 
         $viewHelper = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\ViewHelpers\\Uri\\PageViewHelper',
+            PageViewHelper::class,
             ['getTsfeInstance', 'getTimeTrackerInstance'],
             [],
             '',
@@ -231,14 +236,14 @@ class PageViewHelperTest extends UnitTestCase
     public function getTsfeInstanceReturnsInstanceOfTsfeController()
     {
         $viewHelper = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\ViewHelpers\\Uri\\PageViewHelper',
+            PageViewHelper::class,
             ['dummy'],
             [],
             '',
             false
         );
         $result = $viewHelper->_call('getTsfeInstance');
-        $this->assertInstanceOf('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController', $result);
+        $this->assertInstanceOf(TypoScriptFrontendController::class, $result);
     }
 
     /**
@@ -248,13 +253,13 @@ class PageViewHelperTest extends UnitTestCase
     public function getTimeTrackerInstanceReturnsInstanceOfTsfeController()
     {
         $viewHelper = $this->getAccessibleMock(
-            'DERHANSEN\\SfEventMgt\\ViewHelpers\\Uri\\PageViewHelper',
+            PageViewHelper::class,
             ['dummy'],
             [],
             '',
             false
         );
         $result = $viewHelper->_call('getTimeTrackerInstance');
-        $this->assertInstanceOf('TYPO3\\CMS\\Core\\TimeTracker\\TimeTracker', $result);
+        $this->assertInstanceOf(TimeTracker::class, $result);
     }
 }


### PR DESCRIPTION
This streamlines the use of namespace importing in unit tests. I think I also found a bug, because I had a failing test.