### PR TITLE
[TASK] Remove foreign_types from TCA

### DIFF
--- a/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
@@ -565,13 +565,6 @@ return [
                         'tablenames' => 'tx_sfeventmgt_domain_model_event',
                         'table_local' => 'sys_file',
                     ],
-                    'foreign_types' => [
-                        \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
-                            'showitem' => '--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette,
-                                      --palette--;;imageoverlayPalette,
-                                      --palette--;;filePalette'
-                        ],
-                    ],
                     'overrideChildTca' => [
                         'types' => [
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
@@ -648,13 +641,6 @@ return [
                         'fieldname' => 'additional_image',
                         'tablenames' => 'tx_sfeventmgt_domain_model_event',
                         'table_local' => 'sys_file',
-                    ],
-                    'foreign_types' => [
-                        \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
-                            'showitem' => '--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette,
-                                  --palette--;;imageoverlayPalette,
-                                  --palette--;;filePalette'
-                        ],
                     ],
                     'overrideChildTca' => [
                         'types' => [

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_organisator.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_organisator.php
@@ -175,13 +175,6 @@ return [
                         'tablenames' => 'tx_sfeventmgt_domain_model_organisator',
                         'table_local' => 'sys_file',
                     ],
-                    'foreign_types' => [
-                        \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
-                            'showitem' => '--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette,
-                                      --palette--;;imageoverlayPalette,
-                                      --palette--;;filePalette'
-                        ],
-                    ],
                     'overrideChildTca' => [
                         'types' => [
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_speaker.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_speaker.php
@@ -179,13 +179,6 @@ return [
                         'tablenames' => 'tx_sfeventmgt_domain_model_speaker',
                         'table_local' => 'sys_file',
                     ],
-                    'foreign_types' => [
-                        \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
-                            'showitem' => '--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette,
-                                      --palette--;;imageoverlayPalette,
-                                      --palette--;;filePalette'
-                        ],
-                    ],
                     'overrideChildTca' => [
                         'types' => [
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [


### PR DESCRIPTION
As support for TYPO3 7.6 was removed in b0b0d5e0ba35f558d8a2ab91a53edd63aefb309a the foreign_key is not longer necessary and can be removed.