### PR TITLE
[BUGFIX][670]

### DIFF
--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -29,6 +29,7 @@ class CategoryRepository extends \TYPO3\CMS\Extbase\Domain\Repository\CategoryRe
     {
         $constraints = [];
         $query = $this->createQuery();
+        $query->getQuerySettings()->setRespectSysLanguage(false);
 
         if ($demand->getRestrictToStoragePage()) {
             $pidList = GeneralUtility::intExplode(',', $demand->getStoragePage(), true);


### PR DESCRIPTION
By telling the category repository to ignore the sys_language restrictions
the repository will correctly retrieve the categories based on the uid-list
provided via a flexforms field. Those uis are always selected form the
default language.