### PR TITLE
Language overlay on events

### DIFF
--- a/Classes/Domain/Repository/EventRepository.php
+++ b/Classes/Domain/Repository/EventRepository.php
@@ -41,6 +41,7 @@ class EventRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
     {
         $this->defaultQuerySettings = $this->objectManager->get(Typo3QuerySettings::class);
         $this->defaultQuerySettings->setRespectStoragePage(false);
+        $this->defaultQuerySettings->setLanguageOverlayMode(false);
     }
 
     /**


### PR DESCRIPTION
I have a TYPO3 site that uses two languages, and on one of the pages I have an instance of the calendar on each language, as seen in the following screenshot:

![Screen Shot 2019-10-01 at 11 59 40 AM](https://user-images.githubusercontent.com/2616473/65922784-03d8ea80-e443-11e9-83d1-07257970affc.png)

If I create an English event (which is my default site language), it shows up perfectly fine on the English calendar, however if I create a Māori event, it wouldn't show up on the Māori calendar.

The problem appears to be fixed by adding the `$this->defaultQuerySettings->setLanguageOverlayMode(false);` to the EventRepository.

You have used this code in various parts of the project, just not in the EventRepository, as seen below: 

https://github.com/derhansen/sf_event_mgt/blob/2ce544c01e0cad4fb428de540d4cbd53a662eec5/Classes/Domain/Repository/RegistrationRepository.php#L28-L34

https://github.com/derhansen/sf_event_mgt/blob/2ce544c01e0cad4fb428de540d4cbd53a662eec5/Classes/Domain/Repository/RegistrationRepository.php#L132-L136

Does this look like an appropriate fix?