### PR TITLE
[BUGFIX] Fix Exception in ExportService when registration fields are …

### DIFF
--- a/Classes/Service/ExportService.php
+++ b/Classes/Service/ExportService.php
@@ -133,8 +133,11 @@ class ExportService
         $registrationFieldValues = [];
         /** @var Registration\FieldValue $fieldValue */
         foreach ($registration->getFieldValues() as $fieldValue) {
-            $registrationFieldValues[$fieldValue->getField()->getUid()] =
-                $this->replaceLineBreaks($fieldValue->getValueForCsvExport());
+            $field = $fieldValue->getField();
+            if ($field) {
+                $registrationFieldValues[$field->getUid()] =
+                    $this->replaceLineBreaks($fieldValue->getValueForCsvExport());
+            }
         }
         foreach ($registrationFieldData as $fieldUid => $fieldTitle) {
             if (isset($registrationFieldValues[$fieldUid])) {


### PR DESCRIPTION
We had the case, that the editor first created a custom registration field in the form and did a first test registration. Afterwards he removed that registration field again, but it stayed in this users registration, which led to following exception:

`Core: Exception handler (WEB): Uncaught TYPO3 Exception: Call to a member function getUid() on null | Error thrown in file /app/web/typo3conf/ext/sf_event_mgt/Classes/Service/ExportService.php in line 156. Requested URL: http://test:8000/typo3/index.php?M=web_SfEventMgtTxSfeventmgtM1&moduleToken=--AnonymizedToken--&tx_sfeventmgt_web_sfeventmgttxsfeventmgtm1%5BeventUid%5D=11&tx_sfeventmgt_web_sfeventmgttxsfeventmgtm1%5Baction%5D=export&tx_sfeventmgt_web_sfeventmgttxsfeventmgtm1%5Bcontroller%5D=Administration`  

This error occured with sf_event_mgt 4.1.0 and TYPO3 8.7 and is fixed with this MR.
