### PR TITLE
[Task] Pass "failed" variable explicitly to the template

### DIFF
--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -808,6 +808,7 @@ class EventController extends AbstractController
         }
 
         $values = [
+            'failed' => $failed,
             'messageKey' => $messageKey,
             'titleKey' => $titleKey,
             'event' => $event,
@@ -866,6 +867,7 @@ class EventController extends AbstractController
         }
 
         $values = [
+            'failed' => $failed,
             'messageKey' => $messageKey,
             'titleKey' => $titleKey,
             'event' => $event,


### PR DESCRIPTION
Pass $failed variable explicitly to the confirmation template. Without this it's only possible to get the confirmation status implicitly, if no $event is available in the template.
It can be used to style the output, so a user can get the result of the action easier, e.g. with a callout

Affected templates:
- ConfirmRegistration
- CancelRegistration