### PR TITLE
[BUGFIX] Add service definition

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    DERHANSEN\SfEventMgt\:
+        resource: '../Classes/'

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -5,4 +5,4 @@ services:
         public: false
 
     DERHANSEN\SfEventMgt\:
-        resource: '../Classes/'
+        resource: '../Classes/*'


### PR DESCRIPTION
Without this service definition, no service is registered in the service container, which made it impossible to use these services in other packages.