### PR TITLE
[FEATURE] Add DataProcessor for language navigations

### DIFF
--- a/Classes/DataProcessing/DisableLanguageMenuProcessor.php
+++ b/Classes/DataProcessing/DisableLanguageMenuProcessor.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Extension "sf_event_mgt" for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace DERHANSEN\SfEventMgt\DataProcessing;
+
+use DERHANSEN\SfEventMgt\Utility\EventAvailability;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Routing\PageArguments;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
+
+/**
+ * Disable language item on a detail page if the event is not translated
+ *
+ * 20 = DERHANSEN\SfEventMgt\DataProcessing\DisableLanguageMenuProcessor
+ * 20.menus = languageMenu
+ *
+ */
+class DisableLanguageMenuProcessor implements DataProcessorInterface
+{
+    /**
+     * @param ContentObjectRenderer $cObj
+     * @param array $contentObjectConfiguration
+     * @param array $processorConfiguration
+     * @param array $processedData
+     * @return array
+     */
+    public function process(ContentObjectRenderer $cObj, array $contentObjectConfiguration, array $processorConfiguration, array $processedData)
+    {
+        if (!$processorConfiguration['menus']) {
+            return $processedData;
+        }
+
+        $eventId = $this->getEventId();
+        if ($eventId === 0) {
+            return $processedData;
+        }
+
+        $menus = GeneralUtility::trimExplode(',', $processorConfiguration['menus'], true);
+        foreach ($menus as $menu) {
+            if (isset($processedData[$menu])) {
+                $this->handleMenu($eventId, $processedData[$menu]);
+            }
+        }
+
+        return $processedData;
+    }
+
+    /**
+     * @param int $eventId
+     * @param array $menu
+     */
+    protected function handleMenu(int $eventId, array &$menu): void
+    {
+        $eventAvailability = GeneralUtility::makeInstance(EventAvailability::class);
+        foreach ($menu as &$item) {
+            if (!$item['available']) {
+                continue;
+            }
+            try {
+                $availability = $eventAvailability->check((int)$item['languageId'], $eventId);
+                if (!$availability) {
+                    $item['available'] = false;
+                    $item['availableReason'] = 'sf_event_mgt';
+                }
+            } catch (\Exception $e) {
+            }
+        }
+    }
+
+    /**
+     * @return int
+     */
+    protected function getEventId(): int
+    {
+        $eventId = 0;
+        /** @var PageArguments $pageArguments */
+        $pageArguments = $this->getRequest()->getAttribute('routing');
+        if (isset($pageArguments->getRouteArguments()['tx_sfeventmgt_pievent']['event'])) {
+            $eventId = (int)$pageArguments->getRouteArguments()['tx_sfeventmgt_pievent']['event'];
+        } elseif (isset($this->getRequest()->getQueryParams()['tx_sfeventmgt_pievent']['event'])) {
+            $eventId = (int)$this->getRequest()->getQueryParams()['tx_sfeventmgt_pievent']['event'];
+        }
+
+        return $eventId;
+    }
+
+    /**
+     * @return ServerRequestInterface
+     */
+    protected function getRequest(): ServerRequestInterface
+    {
+        return $GLOBALS['TYPO3_REQUEST'];
+    }
+}

--- a/Classes/Utility/EventAvailability.php
+++ b/Classes/Utility/EventAvailability.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Extension "sf_event_mgt" for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace DERHANSEN\SfEventMgt\Utility;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Site\Entity\SiteInterface;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Check if an event record is available in a language
+ */
+class EventAvailability
+{
+    /**
+     * @param int $languageId
+     * @param int $eventId
+     * @return bool
+     */
+    public function check(int $languageId, int $eventId): bool
+    {
+        /** @var SiteInterface $site */
+        $site = $this->getRequest()->getAttribute('site');
+        $allAvailableLanguagesOfSite = $site->getAllLanguages();
+
+        $targetLanguage = $this->getLanguageFromAllLanguages($allAvailableLanguagesOfSite, $languageId);
+        if (!$targetLanguage) {
+            throw new \UnexpectedValueException('Target language could not be found', 1608059129);
+        }
+        return $this->mustBeIncluded($eventId, $targetLanguage);
+    }
+
+    /**
+     * @param int $eventId
+     * @param SiteLanguage $language
+     * @return bool
+     */
+    protected function mustBeIncluded(int $eventId, SiteLanguage $language): bool
+    {
+        if ($language->getFallbackType() === 'strict' &&
+            !$this->isEventAvailableInLanguage($eventId, $language->getLanguageId())
+        ) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param SiteLanguage[] $allLanguages
+     * @param int $languageId
+     * @return SiteLanguage|null
+     */
+    protected function getLanguageFromAllLanguages(array $allLanguages, int $languageId): ?SiteLanguage
+    {
+        foreach ($allLanguages as $siteLanguage) {
+            if ($siteLanguage->getLanguageId() === $languageId) {
+                return $siteLanguage;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param int $eventId
+     * @param int $language
+     * @return bool
+     */
+    protected function isEventAvailableInLanguage(int $eventId, int $language): bool
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_sfeventmgt_domain_model_event');
+        if ($language === 0) {
+            $where = [
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT)),
+                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(-1, \PDO::PARAM_INT))
+                ),
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($eventId, \PDO::PARAM_INT))
+            ];
+        } else {
+            $where = [
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->andX(
+                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(-1, \PDO::PARAM_INT)),
+                        $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($eventId, \PDO::PARAM_INT))
+                    ),
+                    $queryBuilder->expr()->andX(
+                        $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($eventId, \PDO::PARAM_INT)),
+                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT))
+                    ),
+                    $queryBuilder->expr()->andX(
+                        $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($eventId, \PDO::PARAM_INT)),
+                        $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)),
+                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT))
+                    )
+                )
+            ];
+        }
+
+        $eventsFound = $queryBuilder
+           ->count('uid')
+           ->from('tx_sfeventmgt_domain_model_event')
+           ->where(...$where)
+           ->execute()
+           ->fetchColumn(0);
+        $eventIsAvailable = $eventsFound > 0;
+
+        return $eventIsAvailable;
+    }
+
+    protected function getRequest(): ServerRequestInterface
+    {
+        return $GLOBALS['TYPO3_REQUEST'];
+    }
+}

--- a/Documentation/ForAdministrators/Seo/Index.rst
+++ b/Documentation/ForAdministrators/Seo/Index.rst
@@ -17,7 +17,4 @@ Seo
    :glob:
 
    Sitemap/Index
-
-
-
-
+   LanguageMenu/Index

--- a/Documentation/ForAdministrators/Seo/LanguageMenu/Index.rst
+++ b/Documentation/ForAdministrators/Seo/LanguageMenu/Index.rst
@@ -1,0 +1,28 @@
+.. ==================================================
+.. FOR YOUR INFORMATION
+.. --------------------------------------------------
+.. -*- coding: utf-8 -*- with BOM.
+
+.. include:: ../../Includes.txt
+
+
+.. _languagemenu:
+
+Language menu on news detail pages
+==================================
+
+If a language menu is rendered on a detail page and the languages are configured to use a strict mode, the following snippet
+helps you to setup a proper menu. If no translation exists, the property `available` is set to `false` - just as if the current
+page is not translated.
+
+.. code-block:: typoscript
+
+   10 = TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor
+   10 {
+      as = languageMenu
+      addQueryString = 1
+   }
+
+   11 = DERHANSEN\SfEventMgt\DataProcessing\DisableLanguageMenuProcessor
+   # comma separated list of language menu names
+   11.menus = languageMenu

--- a/Documentation/ForAdministrators/Seo/LanguageMenu/Index.rst
+++ b/Documentation/ForAdministrators/Seo/LanguageMenu/Index.rst
@@ -8,8 +8,8 @@
 
 .. _languagemenu:
 
-Language menu on news detail pages
-==================================
+Language menu on event detail pages
+===================================
 
 If a language menu is rendered on a detail page and the languages are configured to use a strict mode, the following snippet
 helps you to setup a proper menu. If no translation exists, the property `available` is set to `false` - just as if the current


### PR DESCRIPTION
The DataProcessor is to be used on detail pages and disables languages
which are in languageMode=strict and not having a translation for the
current event.

Basically a copy from EXT:news

Relates: #817