### PR TITLE
[BUGFIX] Allow overwrite subject of waitlist moveup mail

### DIFF
--- a/Classes/Hooks/DataHandlerHooks.php
+++ b/Classes/Hooks/DataHandlerHooks.php
@@ -73,6 +73,8 @@ class DataHandlerHooks
                     'settings.notification.registrationWaitlistConfirmed.adminSubject',
                     'settings.notification.registrationCancelled.userSubject',
                     'settings.notification.registrationCancelled.adminSubject',
+                    'settings.notification.registrationWaitlistMoveUp.userSubject',
+                    'settings.notification.registrationWaitlistMoveUp.adminSubject',
                 ],
                 'sDEF' => [
                     'settings.displayMode',


### PR DESCRIPTION
The fields were always saved to flexform, thus their subject was empty