### PR TITLE
[BUGFIX] Correct registration count in translated event

### DIFF
--- a/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
@@ -775,6 +775,8 @@ return [
                     'useSortable' => 1,
                 ],
             ],
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly'
         ],
         'registration_waitlist' => [
             'exclude' => true,
@@ -794,6 +796,8 @@ return [
                     'useSortable' => 1,
                 ],
             ],
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly'
         ],
         'registration_fields' => [
             'exclude' => true,


### PR DESCRIPTION
With l10n_mode=exclude the fields always contains the value of the default language
and thus registrations and registrations in translations are properly mapped.

Resolves: #846 