### PR TITLE
[BUGFIX] Handle non-existent event in checkCancelRegistration()

### DIFF
--- a/Classes/Service/RegistrationService.php
+++ b/Classes/Service/RegistrationService.php
@@ -278,6 +278,12 @@ class RegistrationService
             $titleKey = 'cancelRegistration.title.failed';
         }
 
+        if (!$failed && is_null($registration->getEvent())) {
+            $failed = true;
+            $messageKey = 'event.message.cancel_failed_event_not_found';
+            $titleKey = 'cancelRegistration.title.failed';
+        }
+
         if (!$failed && $registration->getEvent()->getEnableCancel() === false) {
             $failed = true;
             $messageKey = 'event.message.confirmation_failed_cancel_disabled';

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -234,6 +234,9 @@
 			<trans-unit id="event.message.confirmation_failed_registration_not_found">
 				<source>Confirmation failed, registration not found.</source>
 			</trans-unit>
+			<trans-unit id="event.message.cancel_failed_event_not_found">
+				<source>Cancellation failed, event not found.</source>
+			</trans-unit>
 			<trans-unit id="event.message.confirmation_failed_confirmation_until_expired">
 				<source>Confirmation failed, confirmation date has expired.</source>
 			</trans-unit>


### PR DESCRIPTION
This prevents 'Call to a member function getEnableCancel() on null'