### PR TITLE
[BUGFIX] handle multibyte characters in iCal description

### DIFF
--- a/Classes/ViewHelpers/Format/ICalendarDescriptionViewHelper.php
+++ b/Classes/ViewHelpers/Format/ICalendarDescriptionViewHelper.php
@@ -53,10 +53,13 @@ class ICalendarDescriptionViewHelper extends AbstractViewHelper
         $tmpDescription = str_replace(chr(10), '', $tmpDescription);
         // Glue everything together, so every line is max 75 chars
         if (mb_strlen($tmpDescription) > 63) {
-            $newDescription = mb_substr($tmpDescription, 0, 63);
+            $newDescription = mb_substr($tmpDescription, 0, 63) . chr(10);
             $tmpDescription = mb_substr($tmpDescription, 63);
             $arrPieces = mb_str_split($tmpDescription, 75);
-            $newDescription .= chr(10) . ' ' . implode(chr(10) . ' ', $arrPieces);
+            foreach ($arrPieces as &$value) {
+                $value = ' ' . $value;
+            }
+            $newDescription .= implode(chr(10), $arrPieces);
         } else {
             $newDescription = $tmpDescription;
         }

--- a/Classes/ViewHelpers/Format/ICalendarDescriptionViewHelper.php
+++ b/Classes/ViewHelpers/Format/ICalendarDescriptionViewHelper.php
@@ -52,7 +52,7 @@ class ICalendarDescriptionViewHelper extends AbstractViewHelper
         // Strip new lines
         $tmpDescription = str_replace(chr(10), '', $tmpDescription);
         // Glue everything together, so every line is max 75 chars
-        if (strlen($tmpDescription) > 75) {
+        if (strlen($tmpDescription) > 63) {
             $newDescription = substr($tmpDescription, 0, 63);
             $tmpDescription = substr($tmpDescription, 63);
             $arrPieces = str_split($tmpDescription, 74);

--- a/Classes/ViewHelpers/Format/ICalendarDescriptionViewHelper.php
+++ b/Classes/ViewHelpers/Format/ICalendarDescriptionViewHelper.php
@@ -53,13 +53,10 @@ class ICalendarDescriptionViewHelper extends AbstractViewHelper
         $tmpDescription = str_replace(chr(10), '', $tmpDescription);
         // Glue everything together, so every line is max 75 chars
         if (strlen($tmpDescription) > 75) {
-            $newDescription = substr($tmpDescription, 0, 63) . chr(10);
+            $newDescription = substr($tmpDescription, 0, 63);
             $tmpDescription = substr($tmpDescription, 63);
             $arrPieces = str_split($tmpDescription, 74);
-            foreach ($arrPieces as &$value) {
-                $value = ' ' . $value;
-            }
-            $newDescription .= implode(chr(10), $arrPieces);
+            $newDescription .= chr(10) . ' ' . implode(chr(10) . ' ', $arrPieces);
         } else {
             $newDescription = $tmpDescription;
         }

--- a/Classes/ViewHelpers/Format/ICalendarDescriptionViewHelper.php
+++ b/Classes/ViewHelpers/Format/ICalendarDescriptionViewHelper.php
@@ -52,10 +52,10 @@ class ICalendarDescriptionViewHelper extends AbstractViewHelper
         // Strip new lines
         $tmpDescription = str_replace(chr(10), '', $tmpDescription);
         // Glue everything together, so every line is max 75 chars
-        if (strlen($tmpDescription) > 63) {
-            $newDescription = substr($tmpDescription, 0, 63);
-            $tmpDescription = substr($tmpDescription, 63);
-            $arrPieces = str_split($tmpDescription, 74);
+        if (mb_strlen($tmpDescription) > 63) {
+            $newDescription = mb_substr($tmpDescription, 0, 63);
+            $tmpDescription = mb_substr($tmpDescription, 63);
+            $arrPieces = mb_str_split($tmpDescription, 75);
             $newDescription .= chr(10) . ' ' . implode(chr(10) . ' ', $arrPieces);
         } else {
             $newDescription = $tmpDescription;


### PR DESCRIPTION
Without this fix the iCal description is not multibyte character aware.

This results in multibyte character-splitting at line ends:

```text
  bei schwerer betroffenen Erkrankten viel Positives bewirken und ein gröÍ
 tmögliches Maß an Beweglichkeit erhalten. Viele Beispiele und wissensch
```
By wrongly splitting multibyte chars, the Gnome Linux Desktop does not recognize the iCal entry and fails. On other systems e.g. Android with Google calendar the text is displayed broken.

---

As of [RFC5545 Section 3.1](https://www.rfc-editor.org/rfc/rfc5545#section-3.1):
"Lines of text SHOULD NOT be longer than 75 octets, excluding the line break."
– So having less octets/bytes is fine as well.

With multibyte characters I made this assumption for description text:
`In worst case there are a max of 2 bytes per UTF8-character - averaged per line.`
Therefor split to max 37 chars: roughly equals max 74 bytes (plus 1 byte for white-space).

For a more fine-grained solution see:
https://github.com/sabre-io/vobject/blob/06feff370141fd3118609f808e86d9315864bf14/lib/Property.php#L233-L241

Are we compatible to `http://sabre.io/license/ Modified BSD License` – and thereby may use the mentioned code?

---

For unit tests: Waiting for this solution to be selected favorable.

- [ ] Fix existing tests
- [ ] Add multibyte test-cases