### PR TITLE
[BUGFIX] fold long text for SUMMARY and LOCATION in iCal

### DIFF
--- a/Resources/Private/Templates/Event/ICalendar.txt
+++ b/Resources/Private/Templates/Event/ICalendar.txt
@@ -6,10 +6,10 @@ METHOD:PUBLISH
 BEGIN:VEVENT
 UID:{event.uid}-{event.pid}@{typo3Host}
 CLASS: PUBLIC
-SUMMARY:{event.title -> f:format.htmlentitiesDecode()}
+SUMMARY:<e:format.ICalendarDescription>{event.title -> f:format.htmlentitiesDecode()}</e:format.ICalendarDescription>
 DESCRIPTION:<e:format.ICalendarDescription>{event.description -> f:format.htmlentitiesDecode()}</e:format.ICalendarDescription>
 <f:if condition="{event.location}">
-LOCATION:{event.location.title -> f:format.htmlentitiesDecode()}
+LOCATION:<e:format.ICalendarDescription>{event.location.title -> f:format.htmlentitiesDecode()}</e:format.ICalendarDescription>
 </f:if>
 DTSTAMP:<e:format.ICalendarDate>{event.tstamp}</e:format.ICalendarDate>
 DTSTART:<e:format.ICalendarDate>{event.startdate}</e:format.ICalendarDate>


### PR DESCRIPTION
Long text lines for SUMMARY and LOCATION are not folded (split into multiple lines). This is shown as an error in iCal validators.

- `TEXT` is always foldable: [RFC5545 Section 3.3.11](https://www.rfc-editor.org/rfc/rfc5545#section-3.3.11)
- `SUMMARY` is of Value Type `TEXT`: [RFC5545 Section 3.8.1.7](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.12)
- `LOCATION` is of Value Type `TEXT`: [RFC5545 Section 3.8.1.7](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.7)
