### PR TITLE
[BUGFIX] Add missing tab label for event registration in backend

### DIFF
--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -258,6 +258,9 @@
 			<trans-unit id="event.tabs.registrations">
 				<source>Registrations</source>
 			</trans-unit>
+			<trans-unit id="event.tabs.payment">
+				<source>Payment</source>
+			</trans-unit>
 			<trans-unit id="event.sections.payment">
 				<source>Payment</source>
 			</trans-unit>


### PR DESCRIPTION
As there is one label missing in the event registration I added it. Hope the label is fine like that!
