### PR TITLE
[BUGFIX] TypeError on calling `PageUtility::extendPidListByChildren()`

### DIFF
--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -988,7 +988,7 @@ class EventController extends AbstractController
             ',',
             PageUtility::extendPidListByChildren(
                 $this->settings['storagePage'] ?? '',
-                $this->settings['recursive'] ?? 0
+                (int)($this->settings['recursive'] ?? 0)
             ),
             true
         );


### PR DESCRIPTION
This fixes a PHP error caused by missing typecasting `$this->settings['recursive']` to `int` which is already implemented on all other places where `PageUtility::extendPidListByChildren()` is used.