### PR TITLE
[BUGFIX] DisplayMode 'current_future' was not implemented within RegistrationRepository

### DIFF
--- a/Classes/Domain/Repository/RegistrationRepository.php
+++ b/Classes/Domain/Repository/RegistrationRepository.php
@@ -164,6 +164,15 @@ class RegistrationRepository extends Repository
             case 'future':
                 $constraints[] = $query->greaterThan('event.startdate', $demand->getCurrentDateTime());
                 break;
+            case 'current_future':
+                $constraints[] = $query->logicalOr([
+                    $query->greaterThan('event.startdate', $demand->getCurrentDateTime()),
+                    $query->logicalAnd([
+                        $query->greaterThanOrEqual('event.enddate', $demand->getCurrentDateTime()),
+                        $query->lessThanOrEqual('event.startdate', $demand->getCurrentDateTime()),
+                    ]),
+                ]);
+                break;
             case 'past':
                 $constraints[] = $query->lessThanOrEqual('event.enddate', $demand->getCurrentDateTime());
                 break;


### PR DESCRIPTION
The plugin `Pieventregistration` and its `listAction` are able to have `displayMode` configured as `current_future` which should list current & future events user has registered for. Because the case `current_future` is missing within `RegistrationRepository` all events are listed in that case because no constraint was being built.