### PR TITLE
[BUGFIX] Wrong TypoScript path in documentation for migration (plugin.tx_sfeventmgt.settings)

### DIFF
--- a/Documentation/BreakingChanges/Index.rst
+++ b/Documentation/BreakingChanges/Index.rst
@@ -103,7 +103,7 @@ Old::
 New::
 
  plugin.tx_sfeventmgt.settings {
-   details {
+   detail {
      imageWidth = 200
      imageHeight =
    }


### PR DESCRIPTION
In documentation the path to new TypoScript setting was not 100% correct ;-)