### PR TITLE
[TASK] Hide tables in list view

### DIFF
--- a/Configuration/TCA/tx_sfeventmgt_domain_model_registration.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_registration.php
@@ -25,6 +25,7 @@ return [
         ],
         'searchFields' => 'firstname,lastname,address,zip,city,phone,email,gender,confirmed,paid,paymentmethod,payment_reference,notes,fe_user,waitlist,',
         'iconfile' => 'EXT:sf_event_mgt/Resources/Public/Icons/tx_sfeventmgt_domain_model_registration_unconfirmed.svg',
+        'hideTable' => true,
     ],
     'types' => [
         '1' => [

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_registration_field.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_registration_field.php
@@ -66,6 +66,7 @@ return [
         'typeicon_classes' => [
             'default' => 'ext-sfeventmgt-registration-field',
         ],
+        'hideTable' => true,
     ],
     'types' => [
         '0' => [

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_registration_fieldvalue.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_registration_fieldvalue.php
@@ -18,6 +18,7 @@ return [
         'typeicon_classes' => [
             'default' => 'ext-sfeventmgt-registration-field',
         ],
+        'hideTable' => true,
     ],
     'types' => [
         '0' => [


### PR DESCRIPTION
Registrations and related fields are bound to the event and should never be maintained through the direct list. especially on bigger sites there will be multiple registrations with kind of same data. Additionally there is no need to create such records in the list view directly