### PR TITLE
[TASK] Remove t3ver_label field from TCA

### DIFF
--- a/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
@@ -144,14 +144,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_location.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_location.php
@@ -71,15 +71,6 @@ return [
             ],
         ],
 
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
-
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_organisator.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_organisator.php
@@ -68,14 +68,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_priceoption.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_priceoption.php
@@ -67,16 +67,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
-
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_registration_field.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_registration_field.php
@@ -128,14 +128,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',

--- a/Configuration/TCA/tx_sfeventmgt_domain_model_speaker.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_speaker.php
@@ -69,14 +69,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',


### PR DESCRIPTION
The field doesn't have any use anymore since 2019, see https://review.typo3.org/c/Packages/TYPO3.CMS/+/59297/ and furtheremore a notice is removed if an event is moved via clipboard