### PR TITLE
Update ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -50,11 +50,11 @@ call_user_func(function () {
         'SfEventMgt',
         'Pieventregistration',
         [
-            EventController::class => 'registration, saveRegistration, saveRegistrationResult, confirmRegistration, cancelRegistration',
+            EventController::class => 'registration, saveRegistration, saveRegistrationResult, confirmRegistration, cancelRegistration, icalDownload',
         ],
         // non-cacheable actions
         [
-            EventController::class => 'registration, saveRegistration, saveRegistrationResult, confirmRegistration, cancelRegistration',
+            EventController::class => 'registration, saveRegistration, saveRegistrationResult, confirmRegistration, cancelRegistration, icalDownload',
         ]
     );
 


### PR DESCRIPTION
When using the registration view for showing details and the registration form, the iCalDownloadAction is not accessible, but is useful for users.