### PR TITLE
Add dispatch for ProcessRedirectToPaymentEvent

### DIFF
--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -750,6 +750,7 @@ class EventController extends AbstractController
     private function processRedirectToPayment(int $paymentPid, Registration $registration): void
     {
         $processRedirectToPaymentEvent = new ProcessRedirectToPaymentEvent($registration, $this);
+        $this->eventDispatcher->dispatch($processRedirectToPaymentEvent);
         if ($processRedirectToPaymentEvent->getProcessRedirect()) {
             $this->uriBuilder->reset()
                 ->setTargetPageUid($paymentPid);


### PR DESCRIPTION
Added a missing dispatch statement for ProcessRedirectToPaymentEvent. This fixes issue #1114 for v6.x (TYPO3 v11)