### PR TITLE
[BUGFIX] use correct execute method for update statement

### DIFF
--- a/Classes/Updates/PiEventPluginUpdater.php
+++ b/Classes/Updates/PiEventPluginUpdater.php
@@ -205,7 +205,7 @@ class PiEventPluginUpdater implements UpgradeWizardInterface
                     $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
                 )
             )
-            ->executeQuery();
+            ->executeStatement();
     }
 
     /**


### PR DESCRIPTION
Correct use for INSERT, UPDATE and DELETE queries is executeStatement(). When using executeQuery(), you get an error: "Cannot access offset of type string on string" at typo3/cms-core/Classes/Database/Query/QueryBuilder.php line 1314