### PR TITLE
[FEATURE] Added PSR-14 events to modify variables for administration module

### DIFF
--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -17,6 +17,8 @@ use DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand;
 use DERHANSEN\SfEventMgt\Domain\Model\Event;
 use DERHANSEN\SfEventMgt\Domain\Repository\CustomNotificationLogRepository;
 use DERHANSEN\SfEventMgt\Event\InitAdministrationModuleTemplateEvent;
+use DERHANSEN\SfEventMgt\Event\ModifyAdministrationIndexNotifyViewVariablesEvent;
+use DERHANSEN\SfEventMgt\Event\ModifyAdministrationListViewVariablesEvent;
 use DERHANSEN\SfEventMgt\Service\BeUserSessionService;
 use DERHANSEN\SfEventMgt\Service\ExportService;
 use DERHANSEN\SfEventMgt\Service\MaintenanceService;
@@ -263,15 +265,20 @@ class AdministrationController extends AbstractController
             $pagination = $this->getPagination($events, $this->settings['pagination'] ?? []);
         }
 
-        $variables = [
-            'pid' => $this->pid,
-            'events' => $events,
-            'searchDemand' => $searchDemand,
-            'orderByFields' => $this->getOrderByFields(),
-            'orderDirections' => $this->getOrderDirections(),
-            'overwriteDemand' => $overwriteDemand,
-            'pagination' => $pagination,
-        ];
+        $modifyAdministrationListViewVariablesEvent = new ModifyAdministrationListViewVariablesEvent(
+            [
+                'pid' => $this->pid,
+                'events' => $events,
+                'searchDemand' => $searchDemand,
+                'orderByFields' => $this->getOrderByFields(),
+                'orderDirections' => $this->getOrderDirections(),
+                'overwriteDemand' => $overwriteDemand,
+                'pagination' => $pagination,
+            ],
+            $this
+        );
+        $this->eventDispatcher->dispatch($modifyAdministrationListViewVariablesEvent);
+        $variables = $modifyAdministrationListViewVariablesEvent->getVariables();
 
         return $this->initModuleTemplateAndReturnResponse('Administration/List', $variables);
     }
@@ -329,13 +336,18 @@ class AdministrationController extends AbstractController
         $customNotifications = $this->settingsService->getCustomNotifications($this->settings);
         $logEntries = $this->customNotificationLogRepository->findByEvent($event);
 
-        $variables = [
-            'event' => $event,
-            'recipients' => $this->getNotificationRecipients(),
-            'customNotification' => $customNotification,
-            'customNotifications' => $customNotifications,
-            'logEntries' => $logEntries,
-        ];
+        $modifyAdministrationIndexNotifyViewVariablesEvent = new ModifyAdministrationIndexNotifyViewVariablesEvent(
+            [
+                'event' => $event,
+                'recipients' => $this->getNotificationRecipients(),
+                'customNotification' => $customNotification,
+                'customNotifications' => $customNotifications,
+                'logEntries' => $logEntries,
+            ],
+            $this
+        );
+        $this->eventDispatcher->dispatch($modifyAdministrationIndexNotifyViewVariablesEvent);
+        $variables = $modifyAdministrationIndexNotifyViewVariablesEvent->getVariables();
 
         return $this->initModuleTemplateAndReturnResponse('Administration/IndexNotify', $variables);
     }

--- a/Classes/Event/ModifyAdministrationIndexNotifyViewVariablesEvent.php
+++ b/Classes/Event/ModifyAdministrationIndexNotifyViewVariablesEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Extension "sf_event_mgt" for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace DERHANSEN\SfEventMgt\Event;
+
+use DERHANSEN\SfEventMgt\Controller\AdministrationController;
+
+/**
+ * This event is triggered before the administration index notify view is rendered
+ */
+final class ModifyAdministrationIndexNotifyViewVariablesEvent
+{
+    public function __construct(private array $variables, private readonly AdministrationController $administrationController)
+    {
+    }
+
+    public function getVariables(): array
+    {
+        return $this->variables;
+    }
+
+    public function setVariables(array $variables): void
+    {
+        $this->variables = $variables;
+    }
+
+    public function getAdministrationController(): AdministrationController
+    {
+        return $this->administrationController;
+    }
+}

--- a/Classes/Event/ModifyAdministrationListViewVariablesEvent.php
+++ b/Classes/Event/ModifyAdministrationListViewVariablesEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Extension "sf_event_mgt" for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace DERHANSEN\SfEventMgt\Event;
+
+use DERHANSEN\SfEventMgt\Controller\AdministrationController;
+
+/**
+ * This event is triggered before the administration list view is rendered
+ */
+final class ModifyAdministrationListViewVariablesEvent
+{
+    public function __construct(private array $variables, private readonly AdministrationController $administrationController)
+    {
+    }
+
+    public function getVariables(): array
+    {
+        return $this->variables;
+    }
+
+    public function setVariables(array $variables): void
+    {
+        $this->variables = $variables;
+    }
+
+    public function getAdministrationController(): AdministrationController
+    {
+        return $this->administrationController;
+    }
+}

--- a/Tests/Unit/Controller/AdministrationControllerTest.php
+++ b/Tests/Unit/Controller/AdministrationControllerTest.php
@@ -17,10 +17,13 @@ use DERHANSEN\SfEventMgt\Domain\Model\Dto\SearchDemand;
 use DERHANSEN\SfEventMgt\Domain\Model\Event;
 use DERHANSEN\SfEventMgt\Domain\Repository\CustomNotificationLogRepository;
 use DERHANSEN\SfEventMgt\Domain\Repository\EventRepository;
+use DERHANSEN\SfEventMgt\Event\ModifyAdministrationIndexNotifyViewVariablesEvent;
+use DERHANSEN\SfEventMgt\Event\ModifyAdministrationListViewVariablesEvent;
 use DERHANSEN\SfEventMgt\Service\BeUserSessionService;
 use DERHANSEN\SfEventMgt\Service\MaintenanceService;
 use DERHANSEN\SfEventMgt\Service\NotificationService;
 use DERHANSEN\SfEventMgt\Service\SettingsService;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
@@ -88,6 +91,13 @@ class AdministrationControllerTest extends UnitTestCase
         $this->subject->expects(self::once())->method('initModuleTemplateAndReturnResponse')
             ->with('Administration/List', $variables);
 
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
+            ->disableOriginalConstructor()->getMock();
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(
+            new ModifyAdministrationListViewVariablesEvent($variables, $this->subject)
+        );
+        $this->subject->injectEventDispatcher($eventDispatcher);
+
         $this->subject->listAction();
     }
 
@@ -123,6 +133,13 @@ class AdministrationControllerTest extends UnitTestCase
         ];
         $this->subject->expects(self::once())->method('initModuleTemplateAndReturnResponse')
             ->with('Administration/List', $variables);
+
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
+            ->disableOriginalConstructor()->getMock();
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(
+            new ModifyAdministrationListViewVariablesEvent($variables, $this->subject)
+        );
+        $this->subject->injectEventDispatcher($eventDispatcher);
 
         $this->subject->listAction($searchDemand);
     }
@@ -168,6 +185,13 @@ class AdministrationControllerTest extends UnitTestCase
         $this->subject->expects(self::once())->method('initModuleTemplateAndReturnResponse')
             ->with('Administration/List', $variables);
 
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
+            ->disableOriginalConstructor()->getMock();
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(
+            new ModifyAdministrationListViewVariablesEvent($variables, $this->subject)
+        );
+        $this->subject->injectEventDispatcher($eventDispatcher);
+
         $this->subject->listAction($searchDemand);
     }
 
@@ -211,6 +235,13 @@ class AdministrationControllerTest extends UnitTestCase
         ];
         $this->subject->expects(self::once())->method('initModuleTemplateAndReturnResponse')
             ->with('Administration/List', $variables);
+
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
+            ->disableOriginalConstructor()->getMock();
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(
+            new ModifyAdministrationListViewVariablesEvent($variables, $this->subject)
+        );
+        $this->subject->injectEventDispatcher($eventDispatcher);
 
         $this->subject->listAction($searchDemand, ['orderDirection' => 'desc']);
     }
@@ -286,6 +317,13 @@ class AdministrationControllerTest extends UnitTestCase
         ];
         $this->subject->expects(self::once())->method('initModuleTemplateAndReturnResponse')
             ->with('Administration/IndexNotify', $variables);
+
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
+            ->disableOriginalConstructor()->getMock();
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(
+            new ModifyAdministrationIndexNotifyViewVariablesEvent($variables, $this->subject)
+        );
+        $this->subject->injectEventDispatcher($eventDispatcher);
 
         $this->subject->indexNotifyAction($event);
     }


### PR DESCRIPTION
Would be nice to have events similar to the EventController in the AdministratorController.

In my case it was requested to show events recursively from all child folders, which could be realized with the newly added events without having to use XCLASSes.