### PR TITLE
[BUGFIX] Fix: setting disableOverrideDemand not working

### DIFF
--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -948,7 +948,7 @@ class EventController extends AbstractController
      */
     protected function isOverwriteDemand(array $overwriteDemand): bool
     {
-        return ($this->settings['disableOverrideDemand'] ?? 0) != 1 && $overwriteDemand !== [];
+        return (int)($this->settings['disableOverrideDemand'] ?? 0) !== 1 && $overwriteDemand !== [];
     }
 
     /**

--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -948,7 +948,7 @@ class EventController extends AbstractController
      */
     protected function isOverwriteDemand(array $overwriteDemand): bool
     {
-        return ($this->settings['disableOverrideDemand'] ?? 0) !== 1 && $overwriteDemand !== [];
+        return ($this->settings['disableOverrideDemand'] ?? 0) != 1 && $overwriteDemand !== [];
     }
 
     /**


### PR DESCRIPTION
`$this->settings['disableOverrideDemand']` ist type string, this method returns always true, while this setting enabled (value '1'), override demand was not disabled.