### PR TITLE
[BUGFIX] Fix wrong check for waitlist moval

### DIFF
--- a/Classes/Service/RegistrationService.php
+++ b/Classes/Service/RegistrationService.php
@@ -355,7 +355,7 @@ class RegistrationService
     {
         // Early return if move up not enabled, no registrations on waitlist or no free places left
         if (!$event->getEnableWaitlistMoveup() || $event->getRegistrationsWaitlist()->count() === 0 ||
-            $event->getFreePlaces() === 0
+            $event->getFreePlaces() <= 0
         ) {
             return;
         }


### PR DESCRIPTION
The client uses the backend to add additional registrations. Because of this, the count of free places becomes not 0 but negative. because of the wrong check this leads to the bug that *all* valid waiting list registrations are moved from the waiting list to the regular list