### PR TITLE
[BUGFIX] Get correct year for weekConfig. Use ISO 8601 week-numbering year

### DIFF
--- a/Classes/Service/CalendarService.php
+++ b/Classes/Service/CalendarService.php
@@ -165,15 +165,15 @@ class CalendarService
         return [
             'previous' => [
                 'weeknumber' => (int)$firstDayPreviousWeek->format('W'),
-                'year' => (int)$firstDayPreviousWeek->format('Y'),
+                'year' => (int)$firstDayPreviousWeek->format('o'),
             ],
             'current' => [
                 'weeknumber' => (int)$firstDayOfCurrentWeek->format('W'),
-                'year' => (int)$firstDayOfCurrentWeek->format('Y'),
+                'year' => (int)$firstDayOfCurrentWeek->format('o'),
             ],
             'next' => [
                 'weeknumber' => (int)$firstDayNextWeek->format('W'),
-                'year' => (int)$firstDayNextWeek->format('Y'),
+                'year' => (int)$firstDayNextWeek->format('o'),
             ],
         ];
     }


### PR DESCRIPTION
When browsing the calendar by week, I get the wrong year after calendar week 52. It gives me the year 2024 instead of 2025.

https://github.com/derhansen/sf_event_mgt/blob/5fa7286da7f370934b5c7bba5d941e14dcb80bcf/Resources/Private/Templates/Event/Calendar.html#L11-L34

Debugging `$firstDayNextWeek` gives me `2024-12-30` which results in "2024" for the parameter `tx_sfeventmgt_pieventcalendar[overwriteDemand][year]=2024` but it should be 2025.
https://github.com/derhansen/sf_event_mgt/blob/5fa7286da7f370934b5c7bba5d941e14dcb80bcf/Classes/Service/CalendarService.php#L163

This pull request addresses this issue, by using the parameter `o` for formatting the year.

The PHP manual states for the parameter the following:
ISO 8601 week-numbering year. This has the same value as Y, except that if the ISO week number (W) belongs to the previous or next year, that year is used instead.
