### PR TITLE
[FIX] Add missing closing div to Search template

### DIFF
--- a/Resources/Private/Templates/Event/Search.html
+++ b/Resources/Private/Templates/Event/Search.html
@@ -38,8 +38,8 @@
             </div>
 
             <div class="field">
-
-            <f:form.submit value="{f:translate(key:'search.submit')}" class="submit"/>
+                <f:form.submit value="{f:translate(key:'search.submit')}" class="submit"/>
+            </div>
         </div>
     </f:form>
 


### PR DESCRIPTION
The search template is missing a closing `</div>` around the submit button