### PR TITLE
Change 'Organisator' to 'Organizer' in translations

### DIFF
--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -197,7 +197,7 @@
 				<source>Location</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.organisator">
-				<source>Organiser</source>
+				<source>Organizer</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.speaker">
 				<source>Speaker</source>
@@ -206,7 +206,7 @@
 				<source>Record storage page</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.restrictForeignRecordsToStoragePage">
-				<source>Restrict categories, locations, organisers and speakers to storagePage setting (including recursive option)</source>
+				<source>Restrict categories, locations, organizers and speakers to storagePage setting (including recursive option)</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.displayMode.all">
 				<source>Show all events</source>
@@ -331,7 +331,7 @@
 				<source>Create new location</source>
 			</trans-unit>
 			<trans-unit id="administration.newOrganisator">
-				<source>Create new organiser</source>
+				<source>Create new organizer</source>
 			</trans-unit>
 			<trans-unit id="administration.newSpeaker">
 				<source>Create new speaker</source>
@@ -536,16 +536,16 @@
 				<source>The event enddate is before the startdate. Please correct date values, so startdate is before the enddate.</source>
 			</trans-unit>
 			<trans-unit id="event.noOrganisator.title">
-				<source>No organiser</source>
+				<source>No organizer</source>
 			</trans-unit>
 			<trans-unit id="event.noOrganisator.message">
-				<source>The event is configured to notify the organiser, but no organiser is set. Please select an organiser or change the notification settings.</source>
+				<source>The event is configured to notify the organizer, but no organizer is set. Please select an organizer or change the notification settings.</source>
 			</trans-unit>
 			<trans-unit id="event.noOrganisatorEmail.title">
-				<source>Organiser has no email</source>
+				<source>Organizer has no email</source>
 			</trans-unit>
 			<trans-unit id="event.noOrganisatorEmail.message">
-				<source>The event is configured to notify the organiser, but the organiser has no email address. Please set an email address for the organiser or change the notification settings.</source>
+				<source>The event is configured to notify the organizer, but the organizer has no email address. Please set an email address for the organizer or change the notification settings.</source>
 			</trans-unit>
 
 			<trans-unit id="constants.subcategory.registration">


### PR DESCRIPTION
Alter from German spelling to UK English spelling (US English spelling would be organizer if that is the preferred option).