### PR TITLE
Change 'Organisator' to 'Organizer' in locallang.xlf

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -349,7 +349,7 @@
 				<source>Registration failed</source>
 			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_event.organisator">
-				<source>Organiser</source>
+				<source>Organizer</source>
 			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_organisator.name">
 				<source>Name</source>


### PR DESCRIPTION
Alter spelling from German spelling to UK English spelling (US English spelling would be Organizer, if this is the preferred option).