### PR TITLE
Change 'Organisator' to 'Organizer' in translations

### DIFF
--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -97,7 +97,7 @@
 				<source>Speaker</source>
 			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_event.organisator">
-				<source>Organiser</source>
+				<source>Organizer</source>
 			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_event.image">
 				<source>Images</source>
@@ -130,7 +130,7 @@
 				<source>Admin</source>
 			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_event.notify_organisator">
-				<source>Organiser</source>
+				<source>Organizer</source>
 			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_event.meta_keywords">
 				<source>Keywords (,)</source>
@@ -343,10 +343,10 @@
 				<source>Timestamp</source>
 			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_event.organisator">
-				<source>Organiser</source>
+				<source>Organizer</source>
 			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_organisator">
-				<source>Event - Organiser</source>
+				<source>Event - Organizer</source>
 			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_organisator.name">
 				<source>Name</source>


### PR DESCRIPTION
Alter from German spelling to UK English spelling (US English spelling would be organizer if that is the preferred option).