### PR TITLE
[BUG] Added missing overrideChildTca for Event::image

### DIFF
--- a/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_event.php
@@ -665,6 +665,16 @@ return [
                 'type' => 'file',
                 'maxitems' => 999,
                 'allowed' => 'common-image-types',
+                'overrideChildTca' => [
+                    'types' => [
+                        \TYPO3\CMS\Core\Resource\FileType::IMAGE->value => [
+                            'showitem' => '
+                                        --palette--;LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;eventPalette,
+                                        --palette--;;imageoverlayPalette,
+                                        --palette--;;filePalette',
+                        ],
+                    ],
+                ],
             ],
         ],
         'registration' => [


### PR DESCRIPTION
Re-Added missing overrideChildTca config to Event::image TCA in order to add custom eventPalette