### PR TITLE
[TASK] Drop allowLanguageSynchronization from registrations

### DIFF
--- a/Configuration/TCA/tx_sfeventmgt_domain_model_registration.php
+++ b/Configuration/TCA/tx_sfeventmgt_domain_model_registration.php
@@ -283,9 +283,6 @@ return [
                 'type' => 'number',
                 'format' => 'decimal',
                 'size' => 5,
-                'behaviour' => [
-                    'allowLanguageSynchronization' => true,
-                ],
             ],
         ],
         'price_option' => [
@@ -392,9 +389,6 @@ return [
                 'minitems' => 0,
                 'maxitems' => 1,
                 'default' => 0,
-                'behaviour' => [
-                    'allowLanguageSynchronization' => true,
-                ],
             ],
         ],
         'temp_event_uid' => [


### PR DESCRIPTION
The registration table is not localizable: its ctrl section defines neither languageField nor transOrigPointerField. The flag on the `tax_rate` and `event` fields therefore had no effect.