### PR TITLE
[BUGFIX] Prevent exception when validating lazy to-one relations

### DIFF
--- a/Classes/Validation/Validator/TcaSchemaFieldLengthValidator.php
+++ b/Classes/Validation/Validator/TcaSchemaFieldLengthValidator.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractDomainObject;
 use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Error\Result;
+use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
 use TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapFactory;
 use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
 
@@ -116,11 +117,24 @@ final class TcaSchemaFieldLengthValidator extends AbstractValidator
                     $result->forProperty($propertyName)->merge($subResult);
                 }
             } elseif ($propertyValue instanceof \Traversable) {
-                foreach ($propertyValue as $index => $element) {
-                    if ($element instanceof AbstractDomainObject) {
-                        $subResult = $this->validateDomainObject($element);
-                        if ($subResult->hasMessages()) {
-                            $result->forProperty($propertyName)->forProperty((string)$index)->merge($subResult);
+                if ($propertyValue instanceof LazyLoadingProxy) {
+                    $propertyValue = $propertyValue->_loadRealInstance();
+                    if ($propertyValue === null) {
+                        continue;
+                    }
+                }
+                if ($propertyValue instanceof AbstractDomainObject) {
+                    $subResult = $this->validateDomainObject($propertyValue);
+                    if ($subResult->hasMessages()) {
+                        $result->forProperty($propertyName)->merge($subResult);
+                    }
+                } else {
+                    foreach ($propertyValue as $index => $element) {
+                        if ($element instanceof AbstractDomainObject) {
+                            $subResult = $this->validateDomainObject($element);
+                            if ($subResult->hasMessages()) {
+                                $result->forProperty($propertyName)->forProperty((string)$index)->merge($subResult);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
TcaSchemaFieldLengthValidator treated any \Traversable property value as a collection and iterated over it. A lazy-loaded to-one relation (e.g. Category::$parent) is represented by a LazyLoadingProxy, which also implements \Iterator but wraps a single object, not a list. Iterating it triggered an exception instead of validating the related entity.

The proxy is now unwrapped via _loadRealInstance() first; if the result is a single domain object it is validated directly, otherwise the existing collection handling applies as before.